### PR TITLE
Fixed issue with "up" button on the last row.

### DIFF
--- a/collective/z3cform/datagridfield/static/datagridfield.js
+++ b/collective/z3cform/datagridfield/static/datagridfield.js
@@ -159,11 +159,11 @@ jQuery(function($) {
         });
         
         if (idx+1 == validrows) {
-            if (direction = "down") {
+            if (direction == "down") {
                 this.moveRowToTop(row);
             } else {
                 nextRow = rows[idx-1];
-                this.shiftRow(row, nextRow);
+                this.shiftRow(nextRow, row);
             }
             
         } else if (idx == 0) {


### PR DESCRIPTION
Greetings!

I was happily using your plugin when I noticed that clicking on the up arrow for the last row was sending said row to the top instead moving it up one. I tracked the problem to the `datagridfield.js` file where the `direction` variable was accidentally (?) being set rather than being checked against the `"down"` value. The other issue was that arguments to `shiftRow` where in the incorrect order and so I switched them to match the similar code block on line `180`. 
