### PR TITLE
Fix to support zope.schema.interfaces.ValidationError raising from validating row schemas

### DIFF
--- a/collective/z3cform/datagridfield/datagridfield.py
+++ b/collective/z3cform/datagridfield/datagridfield.py
@@ -233,7 +233,9 @@ class DataGridFieldObject(ObjectWidget):
                         try:
                             converter = interfaces.IDataConverter(widget)
                             value[name] = converter.toFieldValue(widget_value)
-                        except (FormatterValidationError, ValueError):
+                        except (FormatterValidationError,
+                                zope.schema.interfaces.ValidationError,
+                                ValueError):
                             value[name] = widget_value
                 return value
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 0.13 (unreleased)
 -----------------
 
+- Fix to expect ``zope.schema.interfaces.ValidationError`` to work better
+  with *TooLong* and *TooShort* exceptions. [datakurre]
+
 - Fix IE7 failing on `<label>` for manipulation [miohtama]
 
 - Deal with situations where there is zero rows on DGF and no auto-append row available [miohtama]


### PR DESCRIPTION
so that we see red boxes when schema row inline validation fails.
