### PR TITLE
Fix testrunner

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,26 +1,25 @@
 [buildout]
-develop = .
-parts = scripts test
+extends = http://dist.plone.org/release/4.3-latest/versions.cfg
 versions = versions
-extends =
-    http://dist.plone.org/release/4.2.2/versions.cfg
+parts = test
+develop = .
 
-[versions]
-zc.buildout = 1.6.3
-
-[scripts]
-recipe = zc.recipe.egg
-eggs =
-    collective.z3cform.datagridfield
-    zest.releaser
-    PasteScript
-    PasteDeploy
-    Paste
+extensions = mr.developer
+sources = sources
+always-accept-server-certificate = true
+always-checkout = true
+auto-checkout =
+    collective.z3cform.datagridfield_demo
 
 [test]
 recipe = zc.recipe.testrunner
-defaults = ['--tests-pattern', '^f?tests$', '-v']
-eggs =
-    Products.CMFPlone
-    Products.PloneTestCase
-    collective.z3cform.datagridfield
+eggs = collective.z3cform.datagridfield[test]
+defaults = ['--auto-color', '--auto-progress']
+
+[sources]
+collective.z3cform.datagridfield_demo = git git://github.com/collective/collective.z3cform.datagridfield_demo.git
+
+# Overrule the ecosystem pinning in Plone's versions.cfg
+[versions]
+collective.z3cform.datagridfield      = 0.13.dev0
+collective.z3cform.datagridfield-demo = 0.6dev

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,13 @@ setup(name='collective.z3cform.datagridfield',
           # -*- Extra requirements: -*-
           'plone.app.z3cform',
           'z3c.form >= 2.4.3dev',
-          'collective.testcaselayer',
       ],
       extras_require={
-        'test': ['collective.z3cform.datagridfield_demo',]
+          'test': [
+              'Products.PloneTestCase',
+              'collective.testcaselayer',
+              'collective.z3cform.datagridfield_demo',
+          ]
       },
       entry_points="""
       # -*- Entry points: -*-


### PR DESCRIPTION
I needed to pin collective.z3cform.datagridfield and collective.z3cform.datagridfield_demo, because of Plone's ecosystem pinning.
