### PR TITLE
Added display_table_css_class attribute on the widget

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,7 @@ The widget can be customised via the updateWidgets method.
         self.widgets['table'].allow_delete = False # Enable/Disable the delete button on the right
         self.widgets['table'].auto_append = False  # Enable/Disable the auto-append feature
         self.widgets['table'].allow_reorder = False  # Enable/Disable the re-order rows feature
+        self.widgets['table'].main_table_css_class = 'my_custom_class'  # Change the class applied on the main table when the field is displayed
 
 The widget contains an attribute 'columns' which is manipulated to hide column
 titles.

--- a/collective/z3cform/datagridfield/datagridfield.py
+++ b/collective/z3cform/datagridfield/datagridfield.py
@@ -49,6 +49,7 @@ class DataGridField(MultiWidget):
     allow_delete = True
     allow_reorder = False
     auto_append = True
+    display_table_css_class = "datagridwidget-table-view"
 
     klass = "datagridfield"
 

--- a/collective/z3cform/datagridfield/datagridfield_display.pt
+++ b/collective/z3cform/datagridfield/datagridfield_display.pt
@@ -4,7 +4,7 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       tal:omit-tag="">
 
-<table class="datagridwidget-table-view">
+<table class="datagridwidget-table-view" tal:attributes="class view/display_table_css_class">
 <thead>
   <tr>
     <tal:block repeat="column view/columns">
@@ -31,4 +31,3 @@
 </table>
 <input type="hidden" tal:replace="structure view/counterMarker" />
 </html>
-

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 0.15 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Added possibility to define the CSS class for the main table when the field is displayed.
+  This way, you can use common Plone existing classes (like 'listing').
+  [gbastien]
 
 
 0.14 (2013-05-24)
@@ -229,4 +231,3 @@ Changelog
 
 * Fixed the restructured text of the main README.txt so that it will show
   more friendly in PyPI.
-


### PR DESCRIPTION
This gives a way to define the css class to use on the main table when the datagridfield is displayed.

See issue #15

Please merge ;-)

Gauthier
