### PR TITLE
changes to fix a datagrid issue of multiple append on change

### DIFF
--- a/collective/z3cform/datagridfield/static/datagridfield.js
+++ b/collective/z3cform/datagridfield/static/datagridfield.js
@@ -134,7 +134,8 @@ jQuery(function($) {
 
         // Re-enable auto-append change handler feature on the new auto-appended row
         if(autoAppendMode) {
-            $('.auto-append > .datagridwidget-cell, .auto-append > .datagridwidget-block-edit-cell').bind("change.dgf", $.proxy(dataGridField2Functions.onInsert, dataGridField2Functions));
+            //$('.auto-append > .datagridwidget-cell, .auto-append > .datagridwidget-block-edit-cell').bind("change.dgf", $.proxy(dataGridField2Functions.onInsert, dataGridField2Functions));
+	    $(dgf).find('.auto-append > .datagridwidget-cell, .auto-append > .datagridwidget-block-edit-cell').bind("change.dgf", $.proxy(dataGridField2Functions.onInsert, dataGridField2Functions));	
         }
 
         dataGridField2Functions.reindexRow(tbody, newtr, 'AA');


### PR DESCRIPTION
The issue was when you have 2 datagrid field for example field A and field B, then if you in field B add more than 1 rows then go to field A and just change something inside the row (which should auto append 1 row) but in this case it was appending the number of extra rows equal to no of rows added in field A,
Problem was it was binding the auto append to all .auto-append class in the page whereas it should bind this event only for .auto-append class in the 1 dgf field in my example in field B.
to fix this
i used $(dgf).find('.auto-append > .datagridwidget-cell, .auto-append > .datagridwidget-block-edit-cell') to find the right element and then binded the 'change.dgf' event on it, this way using $(dgf).find stops me from binding this event to wrong id/element.
