### PR TITLE
Given that the onClick events for the 'new table row' are all inline the...

### DIFF
--- a/collective/z3cform/datagridfield/static/datagridfield.js
+++ b/collective/z3cform/datagridfield/static/datagridfield.js
@@ -193,7 +193,7 @@ jQuery(function($) {
             throw new Error("Could not locate empty template row in DGF");
         }
 
-        var new_row = emptyRow.clone(true).removeClass('datagridwidget-empty-row');
+        var new_row = emptyRow.clone().removeClass('datagridwidget-empty-row');
 
         return new_row;
     };


### PR DESCRIPTION
...re is no need to clone the row with its events as it has none, cloning the <img> tags with onClick tags (that is not the best of markup) causes the page to jump to the top when .clone(true) is fired.
