### PR TITLE
Have select2 interface working with DataGridField

### DIFF
--- a/collective/z3cform/datagridfield/static/datagridfield.js
+++ b/collective/z3cform/datagridfield/static/datagridfield.js
@@ -192,6 +192,17 @@ jQuery(function($) {
         }
 
         var new_row = emptyRow.clone(true).removeClass('datagridwidget-empty-row');
+        
+        // Verifies if there's select2 fields to clone
+        $(new_row.find('.select2-container')).each(function() {
+            var data = $(this).data('select2');
+            if (data != undefined) {
+                var element = data.opts.element.clone(false);
+                data.opts.element = element;
+                $(this).attr("id", "");
+                $(this).select2(data.opts);
+            }
+        });
 
         return new_row;
     };


### PR DESCRIPTION
When a new row is created the empty row is cloned entirely. This works perfectly for regular fields like Text or TextLine. 
When using a widget from plone.app.widgets as subfield, adding a new row places the content at 0px top, 0px left and 0px width. (https://github.com/plone/plone.app.widgets/issues/79)
A cause for this problem is that everytime a select2 element is created it needs to be re-initialised and currently it doesn't happen. 

The fix consists in:
- When creating a new row searches for all select2 elements that the empty row contains.  
- Copies the data from the existing select2.
- Initialises new select2 with previous data.
