### PR TITLE
Fix values not being saved when using select2 widget inside of DataGridField

### DIFF
--- a/collective/z3cform/datagridfield/static/datagridfield.js
+++ b/collective/z3cform/datagridfield/static/datagridfield.js
@@ -192,6 +192,17 @@ jQuery(function($) {
         }
 
         var new_row = emptyRow.clone(true).removeClass('datagridwidget-empty-row');
+        
+        // Verifies if there's select2 fields to clone
+        $(new_row.find('.select2-container')).each(function() {
+            var data = $(this).data('select2');
+            if (data != undefined) {
+                var element = data.opts.element.clone(false);
+                data.opts.element = element;
+                $(this).attr("id", "");
+                $(this).select2(data.opts);
+            }
+        });
 
         return new_row;
     };

--- a/collective/z3cform/datagridfield/static/datagridfield.js
+++ b/collective/z3cform/datagridfield/static/datagridfield.js
@@ -198,9 +198,21 @@ jQuery(function($) {
             var data = $(this).data('select2');
             if (data != undefined) {
                 var element = data.opts.element.clone(false);
-                data.opts.element = element;
-                $(this).attr("id", "");
-                $(this).select2(data.opts);
+
+                // Switch between BlockDataGridField or DataGridField
+                var parent = $(this).parents('.datagridwidget-block');
+                if (!parent.length) {
+                    var parent = $(this).parents('.datagridwidget-cell');
+                }
+
+                // Do not include previous generated elements
+                parent.children().not('div.label').remove();
+                element.attr("value", "");
+                parent.append(element);
+
+
+                // Re-initialise widgets
+                $(document).trigger('init-widgets', [{element: parent}]);
             }
         });
 


### PR DESCRIPTION
When using RelatedItemsWidget or AjaxSelectWidget inside of a DataGridField the values added to a new row are not saved. Values from other subfields (TextLine for example) are saved. The issue is described here: https://github.com/collective/collective.z3cform.datagridfield/issues/38

The problem found is that the cloned widget was not being initialised by plone.app.widgets. Which results in a empty value for each new row.

The fix consists in:
- When creating a new row searches for all select2 elements that the empty row contains.  
- Copies the data from the existing select2.
- Uses plone.app.widgets to initialise the created input element in the new row.
