### PR TITLE
Import AutoExtensibleSubForm from autoform instead of from pautoform …

### DIFF
--- a/collective/z3cform/datagridfield/datagridfield.py
+++ b/collective/z3cform/datagridfield/datagridfield.py
@@ -28,11 +28,14 @@ from plone.app.z3cform.interfaces import IPloneFormLayer
 from interfaces import IDataGridField
 
 try:
-    # support plone.autoform directives within the row schema
-    from pautoform import AutoExtensibleSubForm as ObjectSubForm
-    from autoform import AutoExtensibleSubformAdapter as SubformAdapter
+    from plone import autoform as has_autoform  # noqa # pylint: disable=unused-import
 except ImportError:
-    # Plain z3c ObjectSubForm support
+    has_autoform = None
+if has_autoform:
+    # support plone.autoform directives within the row schema
+    from autoform import AutoExtensibleSubForm as ObjectSubForm
+    from autoform import AutoExtensibleSubformAdapter as SubformAdapter
+else:
     from z3c.form.object import ObjectSubForm
     from z3c.form.object import SubformAdapter
 

--- a/collective/z3cform/datagridfield/datagridfield.py
+++ b/collective/z3cform/datagridfield/datagridfield.py
@@ -28,7 +28,7 @@ from plone.app.z3cform.interfaces import IPloneFormLayer
 from interfaces import IDataGridField
 
 try:
-    from plone import autoform as has_autoform  # noqa # pylint: disable=unused-import
+    from plone import autoform as has_autoform
 except ImportError:
     has_autoform = None
 if has_autoform:


### PR DESCRIPTION
Import AutoExtensibleSubForm from autoform instead of from pautoform does not exist and instead reverts back to using AutoExtensibleSubForm from z3c.form.object

Issue introduced in:
https://github.com/collective/collective.z3cform.datagridfield/commit/9c9000102c8b47b27a609678d9269a3db554e15d#diff-552dc8feb0d191a102754ec6b6190c0aL33