### PR TITLE
Individually initialize each data grid instead of using the default .init method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -219,8 +219,6 @@ The following events are currently fired against ``table.datagridwidget-table-vi
 
 * ``aftermoverow`` [datagridfield]
 
-* ``afterdatagridfieldinit`` - All DGFs on the page have been initialized
-
 Example usage::
 
     var handleDGFInsert = function(event, dgf, row) {

--- a/collective/z3cform/datagridfield/datagridfield_input.pt
+++ b/collective/z3cform/datagridfield/datagridfield_input.pt
@@ -37,5 +37,12 @@
 </tbody>
 </table>
 <input type="hidden" tal:replace="structure view/counterMarker" />
+
+<script type="text/javascript">
+    $().ready(function() {
+        dataGridField2Functions.init('${view/id_prefix}');
+    });
+</script>
+
 </html>
 

--- a/collective/z3cform/datagridfield/static/datagridfield.js
+++ b/collective/z3cform/datagridfield/static/datagridfield.js
@@ -601,51 +601,33 @@ jQuery(function($) {
         return false;
     },
 
+    dataGridField2Functions.init = function(table_id) {
+        var $datagrid_tbody = $('#' + table_id).find('tbody');
+        var datagrid_tbody = $datagrid_tbody[0];
+        var auto_append = $datagrid_tbody.find(".auto-append").length > 0;
 
-    /**
-     * When DOM model is ready execute this actions to wire up page logic.
-     */
-    dataGridField2Functions.init = function() {
+        // Indicate to the data grid that auto append is enabled
+        $datagrid_tbody.data("auto-append", auto_append);
 
-        // Reindex all rows to get proper row classes on them
-        $(".datagridwidget-body").each(function() {
+        // Hint CSS
+        if(auto_append) {
+            $datagrid_tbody.addClass("datagridwidget-body-auto-append");
+        } else {
+            $datagrid_tbody.addClass("datagridwidget-body-non-auto-append");
+        }
 
-            // Initialize widget data on <tbody>
-            // We keep some mode attributes around
-            var $this = $(this);
-            var aa;
+        dataGridField2Functions.updateOrderIndex(datagrid_tbody, false);
 
-            // Check if this widget is in auto-append mode
-            // and store for later usage
-            aa = $this.children(".auto-append").size() > 0;
-            $this.data("auto-append", aa);
-
-            // Hint CSS
-            if(aa) {
-                $this.addClass("datagridwidget-body-auto-append");
-            } else {
-                $this.addClass("datagridwidget-body-non-auto-append");
-            }
-
-            dataGridField2Functions.updateOrderIndex(this, false);
-
-            if(!aa) {
-                dataGridField2Functions.ensureMinimumRows(this);
-            }
-        });
+        if(!auto_append) {
+            dataGridField2Functions.ensureMinimumRows(datagrid_tbody);
+        }
 
         // Bind the handlers to the auto append rows
         // Use namespaced jQuery events to avoid unbind() conflicts later on
-        $('.auto-append .datagridwidget-cell, .auto-append .datagridwidget-block-edit-cell').bind("change.dgf", $.proxy(dataGridField2Functions.onInsert, dataGridField2Functions));
-
-        $(document).trigger("afterdatagridfieldinit");
+        $datagrid_tbody.find('.auto-append .datagridwidget-cell, .auto-append .datagridwidget-block-edit-cell').bind("change.dgf", $.proxy(dataGridField2Functions.onInsert, dataGridField2Functions));
     };
-
-
-    $(document).ready(dataGridField2Functions.init);
 
     // Export module for customizers to mess around
     window.dataGridField2Functions = dataGridField2Functions;
-
 
 });


### PR DESCRIPTION
Individually initalize each data grid on the page to support data grids dynamically inserted as part of mosaic tiles.

Issue:
When the you land on /foo/edit all of the data grids as part of that page's schema exists in the markup.  As a result z3c.datagrid is happy to turn on the data grid functionality on these tables and all works well.

When you click on "Edit" on a mosaic tile the edit form is loaded via AJAX & appended to the DOM, as a result the data grid is not initialized.
