### PR TITLE
Set widget mode on cell widget.

### DIFF
--- a/collective/z3cform/datagridfield/datagridfield_input.pt
+++ b/collective/z3cform/datagridfield/datagridfield_input.pt
@@ -10,8 +10,9 @@
   <tr>
     <tal:block repeat="column view/columns">
       <th class="header"
-          tal:attributes="class string:header cell-${repeat/column/number}"
-         tal:condition="python:column['mode'] != 'hidden'">
+          tal:define="cssclass string:header cell-${repeat/column/number};
+                      cssclass python: cssclass + (column['mode'] == 'hidden' and ' datagridwidget-hidden-data' or '')"
+          tal:attributes="class cssclass">
             <span i18n:translate=""
                 tal:content="column/label">title</span>
             <span class="required"

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,11 +4,14 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
+- Set widget mode on cell widget in order to support autoform mode directive. [jone]
+
 - Bugfix: do not try to update readonly fields. [jone]
 
 
 1.2 (2017-03-08)
 ----------------
+
 - Fix validation exception on readonly fields.
   [rodfersou]
 - Fix bug for widget.klass is NonType in the block view when defining the class for the field.


### PR DESCRIPTION
In order to support ``plone.autoform.directives.mode`` on the cell, the mode is set on the cell widget when updating the widgets. This makes it possible to hide a column using the ``mode`` directive.

The behavior of ``<th>`` and ``<td>`` tags regarding "hidden"-mode was differing: while ``<th>``s were just omitted, ``<td>``s were rendered with a "datagridwidget-hidden-data" CSS class, hiding the cell in CSS. For beeing consistent, the ``<th>`` behavior is changed so that the tag is kept but the same CSS class is used.