### PR TITLE
Bugfix: do not try to update readonly fields.

### DIFF
--- a/collective/z3cform/datagridfield/datagridfield.py
+++ b/collective/z3cform/datagridfield/datagridfield.py
@@ -243,6 +243,10 @@ def datagrid_field_set(self, value):
     if value is not interfaces.NO_VALUE:
         active_names = self.subform.fields.keys()
         for name in getFieldNames(self.field.schema):
+            fieldset_field = self.field.schema[name]
+            if fieldset_field.readonly:
+                continue
+
             if name in active_names:
                 self.applyValue(self.subform.widgets[name],
                                 value.get(name, interfaces.NO_VALUE))

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,14 +4,14 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Bugfix: do not try to update readonly fields. [jone]
 
 
 1.2 (2017-03-08)
 ----------------
 - Fix validation exception on readonly fields.
   [rodfersou]
-- Fix bug for widget.klass is NonType in the block view when defining the class for the field. 
+- Fix bug for widget.klass is NonType in the block view when defining the class for the field.
 - Allow deletion of last row in non-auto-append mode.
   [gaudenz]
 - fixed binding for IChoice fields during validation [djay]


### PR DESCRIPTION
When updating the values of a row, we should not try to update readonly field values.
Updating the value of readonly fields will result in a ``KeyError`` in z3c.form.

This should fix the broken build.