### PR TITLE
Fix pat-registry definition

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ Changelog
 - Move pat-registry inclusion in datagridfield.js to the top.
   [cekk]
 
+- Register datagridfield.js with resource registry (dropped plone 4 compatibility)
+  [cekk]
 
 1.2 (2017-03-08)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ Changelog
 - Move Demo package to in here.
   [jensens]
 
+- Move pat-registry inclusion in datagridfield.js to the top.
+  [cekk]
+
 
 1.2 (2017-03-08)
 ----------------

--- a/src/collective/z3cform/datagridfield/configure.zcml
+++ b/src/collective/z3cform/datagridfield/configure.zcml
@@ -11,6 +11,8 @@
   <!-- Include configuration for dependencies listed in setup.py -->
   <includeDependencies package="." />
   <include package=".demo" />
+  <include file="upgrades.zcml" />
+
   <genericsetup:registerProfile
       name="default"
       title="Data Grid Field for z3c.form"
@@ -24,6 +26,13 @@
       description="Install collective.z3cform.datagridfield"
       provides="Products.GenericSetup.interfaces.EXTENSION"
       directory="profiles/uninstall"
+      />
+  <genericsetup:registerProfile
+      name="to_2"
+      title="Data Grid Field for z3c.form: upgrade profile (to_2)"
+      description="Upgrade collective.z3cform.datagridfield"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      directory="profiles/to_2"
       />
   <utility
       factory=".setuphandlers.HiddenProfiles"

--- a/src/collective/z3cform/datagridfield/profiles/default/jsregistry.xml
+++ b/src/collective/z3cform/datagridfield/profiles/default/jsregistry.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<object name="portal_javascripts">
- <javascript cacheable="True" compression="none" cookable="True"
-    enabled="True" expression=""
-    id="++resource++collective.z3cform.datagridfield/datagridfield.js"
-    inline="False"/>
-</object>
-

--- a/src/collective/z3cform/datagridfield/profiles/default/metadata.xml
+++ b/src/collective/z3cform/datagridfield/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1</version>
+  <version>2</version>
 </metadata>

--- a/src/collective/z3cform/datagridfield/profiles/default/registry.xml
+++ b/src/collective/z3cform/datagridfield/profiles/default/registry.xml
@@ -15,6 +15,7 @@
     </value>
     <value key="enabled">True</value>
     <value key="jscompilation">++resource++collective.z3cform.datagridfield/datagridfield.js</value>
+    <value key="csscompilation">++resource++collective.z3cform.datagridfield/datagridfield.css</value>
     <value key="last_compilation">2019-11-26 00:00:00</value>
     <value key="compile">False</value>
     <value key="depends">plone</value>

--- a/src/collective/z3cform/datagridfield/profiles/default/registry.xml
+++ b/src/collective/z3cform/datagridfield/profiles/default/registry.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<registry>
+  <records prefix="plone.resources/z3cform_datagridfield"
+           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="js">++resource++collective.z3cform.datagridfield/datagridfield.js</value>
+    <value key="css">
+      <element>++resource++collective.z3cform.datagridfield/datagridfield.css</element>
+    </value>
+  </records>
+
+  <records prefix="plone.bundles/datagridfield-bundle"
+           interface='Products.CMFPlone.interfaces.IBundleRegistry'>
+    <value key="resources" purge="false">
+      <element>z3cform_datagridfield</element>
+    </value>
+    <value key="enabled">True</value>
+    <value key="jscompilation">++resource++collective.z3cform.datagridfield/datagridfield.js</value>
+    <value key="last_compilation">2019-11-26 00:00:00</value>
+    <value key="compile">False</value>
+    <value key="depends">plone</value>
+    <value key="merge_with">default</value>
+  </records>
+</registry>

--- a/src/collective/z3cform/datagridfield/profiles/default/registry.xml
+++ b/src/collective/z3cform/datagridfield/profiles/default/registry.xml
@@ -17,7 +17,7 @@
     <value key="jscompilation">++resource++collective.z3cform.datagridfield/datagridfield.js</value>
     <value key="csscompilation">++resource++collective.z3cform.datagridfield/datagridfield.css</value>
     <value key="last_compilation">2019-11-26 00:00:00</value>
-    <value key="compile">False</value>
+    <value key="compile">True</value>
     <value key="depends">plone</value>
     <value key="merge_with">default</value>
   </records>

--- a/src/collective/z3cform/datagridfield/profiles/to_2/browserlayer.xml
+++ b/src/collective/z3cform/datagridfield/profiles/to_2/browserlayer.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<layers>
+  <layer
+      name="collective.z3cform.datagridfield"
+      interface="collective.z3cform.datagridfield.interfaces.IDataGridFieldLayer"
+      />
+</layers>

--- a/src/collective/z3cform/datagridfield/profiles/to_2/cssregistry.xml
+++ b/src/collective/z3cform/datagridfield/profiles/to_2/cssregistry.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
 <object name="portal_css">
     <stylesheet id="++resource++collective.z3cform.datagridfield/datagridfield.css"
-     title="" cacheable="True" compression="safe" cookable="True"
-     enabled="1" expression="" media="screen" rel="stylesheet" rendering="import"
+                remove="True"
      />
  </object>
-

--- a/src/collective/z3cform/datagridfield/profiles/to_2/jsregistry.xml
+++ b/src/collective/z3cform/datagridfield/profiles/to_2/jsregistry.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts">
+ <javascript id="++resource++collective.z3cform.datagridfield/datagridfield.js" remove="True"/>
+</object>

--- a/src/collective/z3cform/datagridfield/setuphandlers.py
+++ b/src/collective/z3cform/datagridfield/setuphandlers.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 from Products.CMFPlone.interfaces import INonInstallable
 from zope.interface import implementer
+import logging
+logger = logging.getLogger(__name__)
+
+default_profile = 'profile-collective.z3cform.datagridfield:default'
 
 
 @implementer(INonInstallable)
@@ -10,4 +14,15 @@ class HiddenProfiles(object):
         """Hide uninstall profile from site-creation and quickinstaller"""
         return [
             'collective.z3cform.datagridfield:uninstall',
+            'collective.z3cform.datagridfield:to_2',
         ]
+
+
+def to_2(context):
+    """
+    """
+    logger.info('Upgrading collective.z3cform.datagridfield to version 2')
+    context.runAllImportStepsFromProfile('profile-collective.z3cform.datagridfield:to_2')
+    context.runImportStepFromProfile(
+        default_profile, 'plone.app.registry')
+    logger.info('Reinstalled registry')

--- a/src/collective/z3cform/datagridfield/static/datagridfield.js
+++ b/src/collective/z3cform/datagridfield/static/datagridfield.js
@@ -179,7 +179,6 @@ require([
         .attr('class', function(i, cls) {
           return cls.replace(/dgw\-disabled-pat-/, 'pat-');
         });
-        // var patRegistry = require('pat-registry');
         patRegistry.scan(new_row);
         return new_row;
     };

--- a/src/collective/z3cform/datagridfield/static/datagridfield.js
+++ b/src/collective/z3cform/datagridfield/static/datagridfield.js
@@ -1,6 +1,9 @@
 /*global window, console*/
 
-jQuery(function($) {
+require([
+  'jquery',
+  'pat-registry',
+], function ($, patRegistry) {
 
     // No globals, dude!
     "use strict";
@@ -176,7 +179,7 @@ jQuery(function($) {
         .attr('class', function(i, cls) {
           return cls.replace(/dgw\-disabled-pat-/, 'pat-');
         });
-        var patRegistry = require('pat-registry');
+        // var patRegistry = require('pat-registry');
         patRegistry.scan(new_row);
         return new_row;
     };

--- a/src/collective/z3cform/datagridfield/upgrades.zcml
+++ b/src/collective/z3cform/datagridfield/upgrades.zcml
@@ -1,0 +1,15 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:gs="http://namespaces.zope.org/genericsetup"
+    i18n_domain="collective.z3cform.datagridfield">
+
+  <!-- Upgrade steps -->
+  <gs:upgradeStep
+        title="Upgrade collective.z3cform.datagridfield to 2"
+        description="collective.z3cform.datagridfield upgrade step"
+        source="1"
+        destination="2"
+        handler=".setuphandlers.to_2"
+        profile="collective.z3cform.datagridfield:default" />
+
+</configure>


### PR DESCRIPTION
On a Plone 5 site, i have the following js error in console.

> require.js:166 Uncaught Error: Module name "pat-registry" has not been loaded yet for context: _. Use require([])
http://requirejs.org/docs/errors.html#notloaded
    at makeError (require.js:166)
    at Object.localRequire [as require] (require.js:1411)
    at requirejs (require.js:1757)
    at Object.dataGridField2Functions.createNewRow (datagridfield.js:182)
    at Object.dataGridField2Functions.autoInsertRow (datagridfield.js:96)
    at Object.dataGridField2Functions.ensureMinimumRows (datagridfield.js:554)
    at HTMLTableSectionElement.<anonymous> (datagridfield.js:in589)
    at Function.each (jquery.js:384)
    at m.fn.init.each (jquery.js:136)
    at HTMLDocument.dataGridField2Functions.init (datagridfield.js:567)

I simply fixed it, using requirejs sintax.
I don't know if this breaks some possible Plone 4 compatibility.