### PR TITLE
Plone 5 modal compatibility

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[report]
+omit =
+    bin/test
+    eggs/*
+    parts/*
+    */lib/*
+    src/collective/__init__.py
+    *.txt
+    *.rst
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-*.pyc
-*.pyo
+*.py[co]
 *.mo
 *.egg-info
 *.egg
@@ -38,8 +37,11 @@ venv
 bin
 devsrc
 buildout-cache
-lib
+lib*
 local
 include
 var
 buildout.cfg
+pip-selfcheck.json
+.idea
+src/plone*

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,21 @@ cache:
   directories:
     - eggs
     - downloads
+  python:
+    - 2.7.15
 env:
   - PLONE_VERSION=4.3
   - PLONE_VERSION=5.0
   - PLONE_VERSION=5.1
 install:
-  - pip install -r requirements.txt
-  - buildout -c test-$PLONE_VERSION.x.cfg -N buildout:download-cache=downloads code-analysis:return-status-codes=True
+  - virtualenv -p `which python` .
+  - bin/pip install -r requirements.txt
+  - bin/buildout -c test-$PLONE_VERSION.x.cfg -N buildout:download-cache=downloads code-analysis:return-status-codes=True
 script:
   - bin/code-analysis
-  - bin/test
+  - bin/coverage run bin/test
 after_success:
-  - bin/createcoverage
-  - pip install coveralls
-  - coveralls
+  - bin/coveralls
 notifications:
   email:
     - dev@bluedynamics.com

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Display column description if provided in schema `field.description`.
+  [gbastien, bleybaert]
 
 1.3.0.post1 (2018-07-16)
 ------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
+- Added missing upgrade step, calling browserlayer setup.
+  [sgeulette]
+
 - Display column description if provided in schema `field.description`.
   [gbastien, bleybaert]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ Changelog
 
 - Display column description if provided in schema `field.description`.
   [gbastien, bleybaert]
+- Specify in README.rst that versions >= 1.3 are for Plone5+ and
+  versions < 1.3 are for Plone4.
+  [gbastien]
 
 1.3.0.post1 (2018-07-16)
 ------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
+- Nothing changed yet.
+
+
+1.3.0.post1 (2018-07-16)
+------------------------
+
 - Extend uninstall profile.
   [thet]
 
@@ -17,6 +23,12 @@ Changelog
 - Removed ols-school ``*`` chars for marking fields as required.
   [keul]
 
+- Fix object access
+  [tomgross]
+
+- Fix usage of related items widget in subforms
+  https://github.com/plone/Products.CMFPlone/issues/2446
+  [tomgross]
 
 1.3.0 (2017-11-22)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,9 +9,16 @@ Changelog
 
 - Display column description if provided in schema `field.description`.
   [gbastien, bleybaert]
+
 - Specify in README.rst that versions >= 1.3 are for Plone5+ and
   versions < 1.3 are for Plone4.
   [gbastien]
+
+- Usability change: add an (hidden) label inside the add commands
+  [keul]
+
+- Compatibility with Plone 5 modals/overlay from mockup
+  [keul]
 
 1.3.0.post1 (2018-07-16)
 ------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
+- Extend uninstall profile.
+  [thet]
+
 - Wrapped commands inside ``A`` tags, required for accessibility reason (change backported from Products.DataGridField).
   This also simplify customizing icons with pure CSS.
   [keul]

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ This product was developed for use with Plone and Dexterity.
 Requirements
 ------------
 
-* Plone >= 4.3
+* Versions >= 1.3 are for Plone 5+, if you use Plone 4.3, use versions 1.2.x
 * z3c.forms
 * A browser with javascript support
 * jquery 1.4.3 or later

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # see https://community.plone.org/t/not-using-bootstrap-py-as-default/620
-rm -r ./lib ./include ./local ./bin
+rm -rf ./lib ./include ./local ./bin
 virtualenv --clear .
 ./bin/pip install -r requirements.txt
 ./bin/buildout

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 setuptools==33.1.1
-zc.buildout==2.8.0
+zc.buildout==2.9.5

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'plone.app.z3cform',
         'plone.autoform',
         'Products.CMFPlone',
+        'plone.api',
         'setuptools',
         'z3c.form >=2.4.3dev',
     ],

--- a/src/collective/z3cform/datagridfield/__init__.py
+++ b/src/collective/z3cform/datagridfield/__init__.py
@@ -1,4 +1,9 @@
 # -*- coding: utf-8 -*-
+
+from zope.i18nmessageid import MessageFactory
+
+_ = MessageFactory('collective.z3cform.datagridfield')
+
 from .blockdatagridfield import BlockDataGridField  # noqa # pylint: disable=unused-import
 from .blockdatagridfield import BlockDataGridFieldFactory  # noqa # pylint: disable=unused-import
 from .datagridfield import DataGridField  # noqa # pylint: disable=unused-import
@@ -6,7 +11,3 @@ from .datagridfield import DataGridFieldFactory  # noqa # pylint: disable=unused
 from .interfaces import IDataGridField  # noqa # pylint: disable=unused-import
 from .interfaces import IRow  # noqa # pylint: disable=unused-import
 from .row import DictRow  # noqa # pylint: disable=unused-import
-from zope.i18nmessageid import MessageFactory
-
-
-_ = MessageFactory('collective.z3cform.datagridfield')

--- a/src/collective/z3cform/datagridfield/autoform.py
+++ b/src/collective/z3cform/datagridfield/autoform.py
@@ -15,6 +15,7 @@ from z3c.form.error import MultipleErrorViewSnippet
 from z3c.form.interfaces import IFormLayer
 from z3c.form.interfaces import IMultipleErrors
 from z3c.form.interfaces import IObjectWidget
+from z3c.form.interfaces import ISubForm
 from z3c.form.interfaces import ISubformFactory
 from zope.component import adapter
 from zope.i18nmessageid import Message
@@ -22,6 +23,7 @@ from zope.interface import implementer
 from zope.interface import Interface
 
 
+@implementer(ISubForm)
 class AutoExtensibleSubForm(AutoExtensibleForm, form.BaseForm):
 
     @property

--- a/src/collective/z3cform/datagridfield/browser.rst
+++ b/src/collective/z3cform/datagridfield/browser.rst
@@ -60,6 +60,12 @@ Make sure the delete row button is present (x4)
     >>> browser.contents.find('<td class="datagridwidget-manipulator delete-row">') != -1
     True
 
+Make sure the description is displayed in the 'personCount' column header
+
+    >>> browser.contents.find('<span>Persons</span>\n            \n            <span class="formHelp">Enter number of persons (min 0 and max 15)</span>') != -1
+    True
+
+
 Make sure resources from our package are not using absolute URLs.  If absolute
 URLs are present, then the resources won't load on anything except where
 Plone/Zope are the root of the domain.

--- a/src/collective/z3cform/datagridfield/configure.zcml
+++ b/src/collective/z3cform/datagridfield/configure.zcml
@@ -1,15 +1,11 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
-    xmlns:five="http://namespaces.zope.org/five"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
-    xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:z3c="http://namespaces.zope.org/z3c"
     xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="collective.z3cform.datagridfield"
     >
-  <!-- Include configuration for dependencies listed in setup.py -->
-  <includeDependencies package="." />
   <include package=".demo" />
   <genericsetup:registerProfile
       name="default"

--- a/src/collective/z3cform/datagridfield/configure.zcml
+++ b/src/collective/z3cform/datagridfield/configure.zcml
@@ -21,6 +21,7 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       directory="profiles/uninstall"
       />
+  <include file="upgrades.zcml" />
   <utility
       factory=".setuphandlers.HiddenProfiles"
       name="collective.z3cform.datagridfield-hiddenprofiles"

--- a/src/collective/z3cform/datagridfield/datagridfield.py
+++ b/src/collective/z3cform/datagridfield/datagridfield.py
@@ -3,13 +3,13 @@
     Implementation of the widget
 """
 from Acquisition import aq_parent
-from Products.CMFCore.utils import getToolByName
 from collective.z3cform.datagridfield.autoform import AutoExtensibleSubForm
 from collective.z3cform.datagridfield.autoform import AutoExtensibleSubformAdapter  # noqa: E501
 from collective.z3cform.datagridfield.interfaces import IDataGridField
 from plone.app.z3cform.interfaces import IPloneFormLayer
 from plone.app.z3cform.utils import closest_content
 from plone.autoform.interfaces import MODES_KEY
+from plone import api
 from z3c.form import interfaces
 from z3c.form.browser.multi import MultiWidget
 from z3c.form.browser.object import ObjectWidget
@@ -212,7 +212,7 @@ class DataGridField(MultiWidget):
             return not name.endswith('AA') and not name.endswith('TT')
 
     def portal_url(self):
-        return getToolByName(self.context, 'portal_url')()
+        return api.portal.get_tool('portal_url')()
 
 
 @adapter(IField, IFormLayer)

--- a/src/collective/z3cform/datagridfield/datagridfield.py
+++ b/src/collective/z3cform/datagridfield/datagridfield.py
@@ -3,6 +3,7 @@
     Implementation of the widget
 """
 from Acquisition import aq_parent
+from Products.CMFCore.utils import getToolByName
 from collective.z3cform.datagridfield.autoform import AutoExtensibleSubForm
 from collective.z3cform.datagridfield.autoform import AutoExtensibleSubformAdapter  # noqa: E501
 from collective.z3cform.datagridfield.interfaces import IDataGridField
@@ -208,6 +209,9 @@ class DataGridField(MultiWidget):
                 return self.auto_append or self.allow_insert
         else:
             return not name.endswith('AA') and not name.endswith('TT')
+
+    def portal_url(self):
+        return getToolByName(self.context, 'portal_url')()
 
 
 @adapter(IField, IFormLayer)

--- a/src/collective/z3cform/datagridfield/datagridfield.py
+++ b/src/collective/z3cform/datagridfield/datagridfield.py
@@ -33,6 +33,7 @@ from zope.schema.interfaces import IField
 from zope.schema.interfaces import IList
 from zope.schema.interfaces import IObject
 from zope.schema.interfaces import ValidationError
+from . import _
 
 import logging
 import lxml
@@ -337,6 +338,12 @@ class DataGridFieldObject(ObjectWidget):
                         )
                 html += lxml.html.tostring(tree) + '\n'
         return html
+
+    def label_add_record(self):
+        return _('add_record_label',
+                 default='Add ${type}',
+                 mapping={'type': self.field.title}
+        )
 
 
 @adapter(IField, interfaces.IFormLayer)

--- a/src/collective/z3cform/datagridfield/datagridfield.py
+++ b/src/collective/z3cform/datagridfield/datagridfield.py
@@ -97,6 +97,7 @@ class DataGridField(MultiWidget):
             col = {
                 'name': name,
                 'label': field.title,
+                'description': field.description,
                 'required': field.required,
                 'mode': fieldmodes.get(name, None),
             }

--- a/src/collective/z3cform/datagridfield/datagridfield.py
+++ b/src/collective/z3cform/datagridfield/datagridfield.py
@@ -35,7 +35,15 @@ from zope.schema.interfaces import ValidationError
 
 import logging
 import lxml
+import pkg_resources
 
+
+try:
+    pkg_resources.get_distribution('z3c.relationfield')
+    from z3c.relationfield.schema import RelationChoice
+    HAS_REL_FIELD = True
+except pkg_resources.DistributionNotFound:
+    HAS_REL_FIELD = False
 
 logger = logging.getLogger(__name__)
 
@@ -256,8 +264,16 @@ def datagrid_field_set(self, value):
                 continue
 
             if name in active_names:
-                self.applyValue(self.subform.widgets[name],
-                                value.get(name, interfaces.NO_VALUE))
+                if isinstance(value, dict):
+                    v = value.get(name, interfaces.NO_VALUE)
+                else:
+                    v = getattr(value, name, interfaces.NO_VALUE)
+                # probably there is a more generic way to do this ...
+                if HAS_REL_FIELD and \
+                        isinstance(fieldset_field, RelationChoice) \
+                        and v == interfaces.NO_VALUE:
+                    v = ''
+                self.applyValue(self.subform.widgets[name], v)
 
 
 PAT_XPATH = "//*[contains(concat(' ', normalize-space(@class), ' '), ' pat-')]"

--- a/src/collective/z3cform/datagridfield/datagridfield.py
+++ b/src/collective/z3cform/datagridfield/datagridfield.py
@@ -340,9 +340,10 @@ class DataGridFieldObject(ObjectWidget):
         return html
 
     def label_add_record(self):
-        return _('add_record_label',
-                 default='Add ${type}',
-                 mapping={'type': self.field.title}
+        return _(
+            'add_record_label',
+            default='Add ${type}',
+            mapping={'type': self.field.title}
         )
 
 

--- a/src/collective/z3cform/datagridfield/datagridfield_input.pt
+++ b/src/collective/z3cform/datagridfield/datagridfield_input.pt
@@ -38,5 +38,6 @@
   </tal:block>
 </tbody>
 </table>
+<script type="text/javascript" src="" tal:attributes="src string:${view/portal_url}/++resource++collective.z3cform.datagridfield/init_field.js"></script>
 <input type="hidden" tal:replace="structure view/counterMarker" />
 </html>

--- a/src/collective/z3cform/datagridfield/datagridfield_input.pt
+++ b/src/collective/z3cform/datagridfield/datagridfield_input.pt
@@ -17,6 +17,7 @@
                 tal:content="column/label">title</span>
             <span class="required"
                   tal:condition="column/required" title="Required" i18n:domain="plone" i18n:attributes="title title_required">&nbsp;</span>
+            <span class="formHelp" tal:condition="column/description" tal:content="column/description">Description</span>
       </th>
     </tal:block>
     <th id="" class="header" tal:condition="view/allow_insert"> </th>

--- a/src/collective/z3cform/datagridfield/datagridfield_input_block.pt
+++ b/src/collective/z3cform/datagridfield/datagridfield_input_block.pt
@@ -28,6 +28,6 @@
   </tal:block>
 </tbody>
 </table>
+<script type="text/javascript" src="" tal:attributes="src string:${view/portal_url}/++resource++collective.z3cform.datagridfield/init_field.js"></script>
 <input type="hidden" tal:replace="structure view/counterMarker" />
 </html>
-

--- a/src/collective/z3cform/datagridfield/datagridfieldobject_input.pt
+++ b/src/collective/z3cform/datagridfield/datagridfieldobject_input.pt
@@ -18,7 +18,7 @@
     </td>
     <td class="datagridwidget-manipulator insert-row"
         tal:condition="view/isInsertEnabled">
-        <a href="" onclick="dataGridField2Functions.addRowAfter(this); return false">
+        <a href="#">
             <img src="++resource++collective.z3cform.datagridfield/add_row_icon.gif"
               alt="Add row"
               i18n:attributes="alt label_datagridwidget_manipulators_addrow"
@@ -27,7 +27,7 @@
     </td>
     <td class="datagridwidget-manipulator delete-row"
         tal:condition="view/isDeleteEnabled">
-        <a href="" onclick="dataGridField2Functions.removeFieldRow(this);return false">
+        <a href="#">
             <img src="++resource++collective.z3cform.datagridfield/delete_row_icon.png"
               alt="Delete row"
               i18n:attributes="alt label_datagridwidget_manipulators_deleterow"
@@ -36,7 +36,7 @@
     </td>
     <td class="datagridwidget-manipulator move-up"
         tal:condition="view/isReorderEnabled">
-        <a href="" onclick="dataGridField2Functions.moveRowUp(this);return false">
+        <a href="#">
             <img src="++resource++collective.z3cform.datagridfield/move_row_up_icon.gif"
               alt="▲" i18n:attributes="alt label_datagridwidget_manipulators_moverowup"
               />
@@ -44,7 +44,7 @@
     </td>
     <td class="datagridwidget-manipulator move-down"
         tal:condition="view/isReorderEnabled">
-        <a href="" onclick="dataGridField2Functions.moveRowDown(this);return false">
+        <a href="#">
             <img src="++resource++collective.z3cform.datagridfield/move_row_down_icon.gif"
               alt="▼" i18n:attributes="alt label_datagridwidget_manipulators_moverowdown"
               />

--- a/src/collective/z3cform/datagridfield/datagridfieldobject_input_block.pt
+++ b/src/collective/z3cform/datagridfield/datagridfieldobject_input_block.pt
@@ -47,6 +47,9 @@
               alt="Add row"
               i18n:attributes="alt label_datagridwidget_manipulators_addrow"
               />
+            <span class="hiddenStructure" tal:content="view/label_add_record">
+                Add new foo
+            </span>
         </a>
     </td>
     <td class="datagridwidget-manipulator delete-row"

--- a/src/collective/z3cform/datagridfield/datagridfieldobject_input_block.pt
+++ b/src/collective/z3cform/datagridfield/datagridfieldobject_input_block.pt
@@ -42,7 +42,7 @@
 
     <td class="datagridwidget-manipulator insert-row"
         tal:condition="view/isInsertEnabled">
-        <a href="" onclick="dataGridField2Functions.addRowAfter(this); return false">
+        <a href="#">
             <img src="++resource++collective.z3cform.datagridfield/add_row_icon.gif"
               alt="Add row"
               i18n:attributes="alt label_datagridwidget_manipulators_addrow"
@@ -51,7 +51,7 @@
     </td>
     <td class="datagridwidget-manipulator delete-row"
         tal:condition="view/isDeleteEnabled">
-        <a href="" onclick="dataGridField2Functions.removeFieldRow(this);return false">
+        <a href="#">
             <img src="++resource++collective.z3cform.datagridfield/delete_row_icon.png"
               alt="Delete row"
               i18n:attributes="alt label_datagridwidget_manipulators_deleterow"
@@ -60,7 +60,7 @@
     </td>
     <td class="datagridwidget-manipulator move-up"
         tal:condition="view/isReorderEnabled">
-        <a href="" onclick="dataGridField2Functions.moveRowUp(this);return false">
+        <a href="#">
             <img src="++resource++collective.z3cform.datagridfield/move_row_up_icon.gif"
               alt="▲" i18n:attributes="alt label_datagridwidget_manipulators_moverowup"
               />
@@ -68,7 +68,7 @@
     </td>
     <td class="datagridwidget-manipulator move-down"
         tal:condition="view/isReorderEnabled">
-        <a href="" onclick="dataGridField2Functions.moveRowDown(this);return false">
+        <a href="#">
             <img src="++resource++collective.z3cform.datagridfield/move_row_down_icon.gif"
               alt="▼" i18n:attributes="alt label_datagridwidget_manipulators_moverowdown"
               />

--- a/src/collective/z3cform/datagridfield/demo/editform_object.py
+++ b/src/collective/z3cform/datagridfield/demo/editform_object.py
@@ -20,6 +20,9 @@ from zope.interface import Interface
 from zope.component import adapter
 from zope.schema import getFieldsInOrder
 from zope.schema.fieldproperty import FieldProperty
+# Uncomment, if you want to try the relationfield
+# from plone.app.vocabularies.catalog import CatalogSource
+# from z3c.relationfield.schema import RelationChoice
 
 
 class IAddress(Interface):
@@ -43,6 +46,11 @@ class IAddress(Interface):
         title=u'Country',
         required=True
     )
+# Uncomment, if you want to try the relationfield
+#    link = RelationChoice(
+#        title=u"Link to content",
+#        source=CatalogSource(portal_type=['Document']),
+#        required=False)
 
 
 class AddressListField(schema.List):
@@ -67,14 +75,20 @@ class Address(object):
     line2 = FieldProperty(IAddress['line2'])
     city = FieldProperty(IAddress['city'])
     country = FieldProperty(IAddress['country'])
+# Uncomment, if you want to try the relationfield
+#    link = FieldProperty(IAddress['link'])
+
+    # allow getSource to proceed
+    _Modify_portal_content_Permission = ('Anonymous', )
 
     def __init__(self, address_type=None, line1=None, line2=None, city=None,
-                 country=None):
+                 country=None, link=None):
         self.address_type = address_type
         self.line1 = line1
         self.line2 = line2
         self.city = city
         self.country = country
+        self.link = link
 
 
 class AddressList(list):
@@ -85,6 +99,9 @@ class AddressList(list):
 class Person(object):
     name = FieldProperty(IPerson['name'])
     address = FieldProperty(IPerson['address'])
+
+    # allow getSource to proceed
+    _Modify_portal_content_Permission = ('Anonymous', )
 
     def __init__(self, name=None, address=None):
         self.name = name

--- a/src/collective/z3cform/datagridfield/demo/editform_simple.py
+++ b/src/collective/z3cform/datagridfield/demo/editform_simple.py
@@ -8,6 +8,7 @@ from collective.z3cform.datagridfield import BlockDataGridFieldFactory
 from collective.z3cform.datagridfield import DataGridFieldFactory
 from collective.z3cform.datagridfield import DictRow
 from datetime import datetime
+from plone.autoform.directives import widget
 from z3c.form import button
 from z3c.form import field
 from z3c.form import form
@@ -15,9 +16,9 @@ from z3c.form.interfaces import DISPLAY_MODE
 from z3c.form.interfaces import HIDDEN_MODE
 from zope import schema
 from zope.interface import Interface
-from plone.autoform.directives import widget
-
-import z3c.form
+# Uncomment, if you want to try the relationfield
+# from plone.app.vocabularies.catalog import CatalogSource
+# from z3c.relationfield.schema import RelationChoice
 
 
 try:
@@ -25,7 +26,9 @@ try:
 except ImportError:
     widget_datetime = None
 
+
 if widget_datetime is not None:
+    from z3c.form.widget import FieldWidget
 
     class DataGridFieldDatetimeWidget(widget_datetime.DatetimeWidget):
         # Causes grey hair because of invalid value handling
@@ -34,22 +37,19 @@ if widget_datetime is not None:
 
     def DataGridFieldDatetimeFieldWidget(field, request):
         """IFieldWidget factory for DatetimeWidget."""
-        return z3c.form.widget.FieldWidget(
-            field,
-            DataGridFieldDatetimeWidget(request)
-        )
+        return FieldWidget(field, DataGridFieldDatetimeWidget(request))
 
 
 class IAddress(Interface):
     address_type = schema.Choice(
         title=u'Address Type', required=True,
         values=[u'Work', u'Home'])
-    # A Relation field within a datagrid is a tricky one to get
-    # working.  Uncomment if you want to try this.
-    # link = RelationChoice(
-    #         title=u"Link to content",
-    #         source=ObjPathSourceBinder(),
-    #         required=True)
+# Uncomment, if you want to try the relationfield
+#    link = RelationChoice(
+#        title=u"Link to content",
+#        source=CatalogSource(portal_type=['Document']),
+#        required=True
+#    )
     line1 = schema.TextLine(
         title=u'Line 1', required=True)
     line2 = schema.TextLine(

--- a/src/collective/z3cform/datagridfield/demo/editform_simple.py
+++ b/src/collective/z3cform/datagridfield/demo/editform_simple.py
@@ -62,7 +62,12 @@ class IAddress(Interface):
         title=u'Don\'t change', readonly=True, required=True)
 
     # A sample integer field
-    personCount = schema.Int(title=u'Persons', required=False, min=0, max=15)
+    personCount = schema.Int(
+        title=u'Persons',
+        description=u'Enter number of persons (min 0 and max 15)',
+        required=False,
+        min=0,
+        max=15)
 
     # A sample datetime field
     if widget_datetime is not None:

--- a/src/collective/z3cform/datagridfield/profiles/default/metadata.xml
+++ b/src/collective/z3cform/datagridfield/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1</version>
+  <version>2</version>
 </metadata>

--- a/src/collective/z3cform/datagridfield/profiles/uninstall/browserlayer.xml
+++ b/src/collective/z3cform/datagridfield/profiles/uninstall/browserlayer.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <layers>
-  <layer
-      name="collective.z3cform.datagridfield"
-      remove="true"
-      />
+  <layer remove="true" name="collective.z3cform.datagridfield"/>
 </layers>

--- a/src/collective/z3cform/datagridfield/profiles/uninstall/cssregistry.xml
+++ b/src/collective/z3cform/datagridfield/profiles/uninstall/cssregistry.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<object name="portal_css">
+  <stylesheet remove="true" id="++resource++collective.z3cform.datagridfield/datagridfield.css"/>
+</object>

--- a/src/collective/z3cform/datagridfield/profiles/uninstall/jsregistry.xml
+++ b/src/collective/z3cform/datagridfield/profiles/uninstall/jsregistry.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts">
+  <javascript remove="true" id="++resource++collective.z3cform.datagridfield/datagridfield.js"/>
+</object>

--- a/src/collective/z3cform/datagridfield/static/datagridfield.css
+++ b/src/collective/z3cform/datagridfield/static/datagridfield.css
@@ -64,30 +64,30 @@
 }
 
 /* You cannot delete the auto-append row */
-.auto-append  > .datagridwidget-manipulator.delete-row img,
-.auto-append  > .datagridwidget-manipulator.move-up img,
-.auto-append  > .datagridwidget-manipulator.move-down img,
-.auto-append  > .datagridwidget-manipulator.insert-row img {
+.auto-append  > .datagridwidget-manipulator.delete-row a,
+.auto-append  > .datagridwidget-manipulator.move-up a,
+.auto-append  > .datagridwidget-manipulator.move-down a,
+.auto-append  > .datagridwidget-manipulator.insert-row a {
     display: none;
 }
 
 /* When no AA mode, only one row in the widget */
-.minimum-row  > .datagridwidget-manipulator.insert-row img {
+.minimum-row  > .datagridwidget-manipulator.insert-row a {
     display: block;
 }
 
-.datagridwidget-body-non-auto-append[data-many-rows = "true"] .datagridfield-last-filled-row > .datagridwidget-manipulator.move-down img,
-.datagridwidget-body-non-auto-append[data-many-rows = "true"] .datagridfield-first-filled-row > .datagridwidget-manipulator.move-up img {
+.datagridwidget-body-non-auto-append[data-many-rows = "true"] .datagridfield-last-filled-row > .datagridwidget-manipulator.move-down a,
+.datagridwidget-body-non-auto-append[data-many-rows = "true"] .datagridfield-first-filled-row > .datagridwidget-manipulator.move-up a {
     display: block;
 }
 
 /* Cannot move up out of the grid */
-.datagridfield-first-filled-row > .datagridwidget-manipulator.move-up img {
+.datagridfield-first-filled-row > .datagridwidget-manipulator.move-up a {
     display: none !important;
 }
 
 /* Cannot move below auto-append row */
-.datagridfield-last-filled-row > .datagridwidget-manipulator.move-down img {
+.datagridfield-last-filled-row > .datagridwidget-manipulator.move-down a {
     display: none !important;
 }
 

--- a/src/collective/z3cform/datagridfield/static/datagridfield.js
+++ b/src/collective/z3cform/datagridfield/static/datagridfield.js
@@ -127,14 +127,18 @@ jQuery(function($) {
      *
      * @param {Object} currnode DOM <tr>
      */
-    dataGridField2Functions.addRowAfter = function(currnode) {
+    dataGridField2Functions.addRowAfter = function(evt) {
+        evt.preventDefault();
+        evt.stopPropagation();
+        var currnode = this;
+
         // fetch required data structure
-        var tbody = this.getParentByClass(currnode, "datagridwidget-body");
+        var tbody = dataGridField2Functions.getParentByClass(currnode, "datagridwidget-body");
         var dgf = $(dataGridField2Functions.getParentByClass(currnode, "datagridwidget-table-view"));
-        var thisRow = this.getParentRow(currnode);
-        var newtr = this.createNewRow(thisRow);
+        var thisRow = dataGridField2Functions.getParentRow(currnode);
+        var newtr = dataGridField2Functions.createNewRow(thisRow);
         dgf.trigger("beforeaddrow", [dgf, newtr]);
-        var filteredRows = this.getVisibleRows(currnode);
+        var filteredRows = dataGridField2Functions.getVisibleRows(currnode);
 
         // If using auto-append we add the "real" row before AA
         // We have a special case when there is only one visible in the gid
@@ -146,11 +150,11 @@ jQuery(function($) {
 
         // Ensure minimum special behavior is no longer needed as we have now at least 2 rows
         if(thisRow.hasClass("minimum-row")) {
-            this.supressEnsureMinimum(tbody);
+            dataGridField2Functions.supressEnsureMinimum(tbody);
         }
 
         // update orderindex hidden fields
-        this.updateOrderIndex(tbody, true);
+        dataGridField2Functions.updateOrderIndex(tbody, true);
         dgf.trigger("afteraddrow", [dgf, newtr]);
     };
 
@@ -182,15 +186,18 @@ jQuery(function($) {
     };
 
 
-    dataGridField2Functions.removeFieldRow = function(node) {
+    dataGridField2Functions.removeFieldRow = function(evt) {
+        evt.preventDefault();
+        evt.stopPropagation();
+        var node = this;
         /* Remove the row in which the given node is found */
-        var tbody = this.getParentByClass(node, "datagridwidget-body");
-        var row = this.getParentRow(node);
+        var tbody = dataGridField2Functions.getParentByClass(node, "datagridwidget-body");
+        var row = dataGridField2Functions.getParentRow(node);
         $(row).remove();
         // ensure minimum rows in non-auto-append mode, reindex if no
         // minimal row was added, otherwise reindexing is done by ensureMinimumRows
-        if ($(tbody).data("auto-append") || !this.ensureMinimumRows(tbody)) {
-            this.updateOrderIndex(tbody, false);
+        if ($(tbody).data("auto-append") || !dataGridField2Functions.ensureMinimumRows(tbody)) {
+            dataGridField2Functions.updateOrderIndex(tbody, false);
         }
     };
 
@@ -254,12 +261,16 @@ jQuery(function($) {
         dgf.trigger("aftermoverow", [dgf, row]);
     };
 
-    dataGridField2Functions.moveRowDown = function(currnode){
-        this.moveRow(currnode, "down");
+    dataGridField2Functions.moveRowDown = function(evt){
+        evt.preventDefault();
+        evt.stopPropagation();
+        dataGridField2Functions.moveRow(this, "down");
     };
 
-    dataGridField2Functions.moveRowUp = function(currnode){
-        this.moveRow(currnode, "up");
+    dataGridField2Functions.moveRowUp = function(evt){
+        evt.preventDefault();
+        evt.stopPropagation();
+        dataGridField2Functions.moveRow(this, "up");
     };
 
     dataGridField2Functions.shiftRow = function(bottom, top){
@@ -568,6 +579,21 @@ jQuery(function($) {
             var $this = $(this);
             var aa;
 
+            // Do not try to init this field more than once
+            // This may happen inside mockup modals
+            if ($this.data('datagrid-enabled')) {
+                return;
+            }
+            $this.data('datagrid-enabled', true);
+
+            // Init commands
+            // BBB: I need .off usage down there due to mockup mess inside overlay/modals
+            // Also tried with loadLinksWithinModal to false...
+            $('.datagridwidget-manipulator.insert-row a', $this).off('click').on('click', dataGridField2Functions.addRowAfter);
+            $('.datagridwidget-manipulator.delete-row a', $this).off('click').on('click', dataGridField2Functions.removeFieldRow);
+            $('.datagridwidget-manipulator.move-up a', $this).off('click').on('click', dataGridField2Functions.moveRowUp);
+            $('.datagridwidget-manipulator.move-down a', $this).off('click').on('click', dataGridField2Functions.moveRowDown);
+
             // Check if this widget is in auto-append mode
             // and store for later usage
             aa = $this.children(".auto-append").size() > 0;
@@ -594,11 +620,16 @@ jQuery(function($) {
         $(document).trigger("afterdatagridfieldinit");
     };
 
-
     $(document).ready(dataGridField2Functions.init);
+
+    // Init commands
+    // Event delegation is not working due to mockup mess, even if I try with loadLinksWithinModal false
+    // $(document).on('click', '.datagridwidget-manipulator.insert-row a', dataGridField2Functions.addRowAfter);
+    // $(document).on('click', '.datagridwidget-manipulator.delete-row a', dataGridField2Functions.removeFieldRow);
+    // $(document).on('click', '.datagridwidget-manipulator.move-up a', dataGridField2Functions.moveRowUp);
+    // $(document).on('click', '.datagridwidget-manipulator.move-down a', dataGridField2Functions.moveRowDown);
 
     // Export module for customizers to mess around
     window.dataGridField2Functions = dataGridField2Functions;
-
 
 });

--- a/src/collective/z3cform/datagridfield/static/datagridfield.js
+++ b/src/collective/z3cform/datagridfield/static/datagridfield.js
@@ -92,7 +92,9 @@ jQuery(function($) {
         // Create a new row
         var newtr = dataGridField2Functions.createNewRow(thisRow), $newtr = $(newtr);
         // Add auto-append functionality to our new row
-        $newtr.addClass('auto-append');
+        if (autoAppendMode) {
+            $newtr.addClass('auto-append');
+        }
 
         /* Put new row to DOM tree after our current row.  Do this before
          * reindexing to ensure that any Javascript we insert that depends on
@@ -141,7 +143,7 @@ jQuery(function($) {
         var filteredRows = dataGridField2Functions.getVisibleRows(currnode);
 
         // If using auto-append we add the "real" row before AA
-        // We have a special case when there is only one visible in the gid
+        // We have a special case when there is only one visible in the grid
         if (thisRow.hasClass('auto-append') && !thisRow.hasClass("minimum-row")) {
             $(newtr).insertBefore(thisRow);
         } else {

--- a/src/collective/z3cform/datagridfield/static/init_field.js
+++ b/src/collective/z3cform/datagridfield/static/init_field.js
@@ -1,0 +1,6 @@
+(function($) {
+  if (window.dataGridField2Functions) {
+    // hack for load datagrid stuff in overlay/modals
+    window.dataGridField2Functions.init();
+  }
+})(jQuery);

--- a/src/collective/z3cform/datagridfield/testing.py
+++ b/src/collective/z3cform/datagridfield/testing.py
@@ -2,7 +2,6 @@
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
-from zope.configuration import xmlconfig
 
 
 class Fixture(PloneSandboxLayer):
@@ -10,13 +9,8 @@ class Fixture(PloneSandboxLayer):
     defaultBases = (PLONE_FIXTURE,)
 
     def setUpZope(self, app, configurationContext):
-
         import collective.z3cform.datagridfield
-        xmlconfig.file(
-            'configure.zcml',
-            collective.z3cform.datagridfield,
-            context=configurationContext
-        )
+        self.loadZCML(package=collective.z3cform.datagridfield)
 
     def setUpPloneSite(self, portal):
         self.applyProfile(portal, 'collective.z3cform.datagridfield:default')
@@ -24,6 +18,6 @@ class Fixture(PloneSandboxLayer):
 
 FIXTURE = Fixture()
 FUNCTIONAL_TESTING = FunctionalTesting(
-    bases=(FIXTURE,),
+    bases=(FIXTURE, ),
     name='collective.z3cform.datagridfield:Functional',
 )

--- a/src/collective/z3cform/datagridfield/tests.py
+++ b/src/collective/z3cform/datagridfield/tests.py
@@ -28,7 +28,3 @@ def test_suite():
         )
     ])
     return suite
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='test_suite')

--- a/src/collective/z3cform/datagridfield/upgrades.zcml
+++ b/src/collective/z3cform/datagridfield/upgrades.zcml
@@ -1,0 +1,14 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="collective.z3cform.datagridfield">
+
+  <genericsetup:upgradeDepends
+      title="Go to collective.z3cform.datagridfield 1.3.0"
+      source="1"
+      destination="2"
+      profile="collective.z3cform.datagridfield:default"
+      import_steps="browserlayer"
+      />
+
+</configure>

--- a/test-4.3.x.cfg
+++ b/test-4.3.x.cfg
@@ -1,11 +1,5 @@
 [buildout]
 extends =
     https://raw.github.com/collective/buildout.plonetest/master/test-4.3.x.cfg
-    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
-    versions.cfg
+    test-base.cfg
 
-package-name = collective.z3cform.datagridfield
-package-extras = [test]
-
-[code-analysis]
-directory = collective

--- a/test-5.0.x.cfg
+++ b/test-5.0.x.cfg
@@ -1,11 +1,5 @@
 [buildout]
 extends =
     https://raw.github.com/collective/buildout.plonetest/master/test-5.0.x.cfg
-    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
-    versions.cfg
-
-package-name = collective.z3cform.datagridfield
-package-extras = [test]
-
-[code-analysis]
-directory = collective
+    http://dist.plone.org/release/5.0.6/versions.cfg
+    test-base.cfg

--- a/test-5.1.x.cfg
+++ b/test-5.1.x.cfg
@@ -1,11 +1,4 @@
 [buildout]
 extends =
     https://raw.github.com/collective/buildout.plonetest/master/test-5.1.x.cfg
-    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
-    versions.cfg
-
-package-name = collective.z3cform.datagridfield
-package-extras = [test]
-
-[code-analysis]
-directory = collective
+    test-base.cfg

--- a/test-base.cfg
+++ b/test-base.cfg
@@ -1,0 +1,20 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
+    versions.cfg
+
+package-name = collective.z3cform.datagridfield
+package-extras = [test]
+parts += coverage
+
+[code-analysis]
+directory = src/collective
+
+
+[coverage]
+recipe = zc.recipe.egg
+eggs =
+   ${test:eggs}
+   coverage
+   python-coveralls
+

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,7 +1,7 @@
 [versions]
 # pin according to requirements.
 setuptools = 33.1.1
-zc.buildout = 2.8.0
+zc.buildout = 2.9.5
 
 # Unpin Plone's versions.cfg pinning.
 collective.z3cform.datagridfield      =
@@ -16,8 +16,8 @@ check-manifest = 0.35
 clint = 0.5.1
 colorama = 0.3.7
 configparser = 3.5.0
-coverage = 3.7.1
-createcoverage = 1.5
+coverage = 4.0.3
+python-coveralls = 2.7.0
 enum34 = 1.1.6
 flake8 = 3.3.0
 flake8-blind-except = 0.1.1


### PR DESCRIPTION
Main change: this widget was not usable at all on Plone 5/mockup/overlay due to usage of simple document.ready.

Changes performed are minimal to keep it compatible with Plone 4, when Plone 4 will be dropped a more deep JavaScript refactoring if probably a better way to go (maybe with a new patterns?).

Plus: added some accessibility fixes already merged in the old AT DataGridField.