### PR TITLE
Display column description if provided in schema `field.description`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Display column description if provided in schema `field.description`.
+  [gbastien, bleybaert]
 
 1.3.0.post1 (2018-07-16)
 ------------------------

--- a/src/collective/z3cform/datagridfield/browser.rst
+++ b/src/collective/z3cform/datagridfield/browser.rst
@@ -60,6 +60,12 @@ Make sure the delete row button is present (x4)
     >>> browser.contents.find('<td class="datagridwidget-manipulator delete-row">') != -1
     True
 
+Make sure the description is displayed in the 'personCount' column header
+
+    >>> browser.contents.find('<span>Persons</span>\n            \n            <span class="formHelp">Enter number of persons (min 0 and max 15)</span>') != -1
+    True
+
+
 Make sure resources from our package are not using absolute URLs.  If absolute
 URLs are present, then the resources won't load on anything except where
 Plone/Zope are the root of the domain.

--- a/src/collective/z3cform/datagridfield/datagridfield.py
+++ b/src/collective/z3cform/datagridfield/datagridfield.py
@@ -97,6 +97,7 @@ class DataGridField(MultiWidget):
             col = {
                 'name': name,
                 'label': field.title,
+                'description': field.description,
                 'required': field.required,
                 'mode': fieldmodes.get(name, None),
             }

--- a/src/collective/z3cform/datagridfield/datagridfield_input.pt
+++ b/src/collective/z3cform/datagridfield/datagridfield_input.pt
@@ -17,6 +17,7 @@
                 tal:content="column/label">title</span>
             <span class="required"
                   tal:condition="column/required" title="Required" i18n:domain="plone" i18n:attributes="title title_required">&nbsp;</span>
+            <span class="formHelp" tal:condition="column/description" tal:content="column/description">Description</span>
       </th>
     </tal:block>
     <th id="" class="header" tal:condition="view/allow_insert"> </th>

--- a/src/collective/z3cform/datagridfield/demo/editform_simple.py
+++ b/src/collective/z3cform/datagridfield/demo/editform_simple.py
@@ -62,7 +62,12 @@ class IAddress(Interface):
         title=u'Don\'t change', readonly=True, required=True)
 
     # A sample integer field
-    personCount = schema.Int(title=u'Persons', required=False, min=0, max=15)
+    personCount = schema.Int(
+        title=u'Persons',
+        description=u'Enter number of persons (min 0 and max 15)',
+        required=False,
+        min=0,
+        max=15)
 
     # A sample datetime field
     if widget_datetime is not None:


### PR DESCRIPTION
This is related to issur #75 

Thank you for review!

I will also back port this to branch 1.2.x as we need this for a Plone4.3 application.

Gauthier