### PR TITLE
Plone 4: Make patterns lib support optional.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make patterns lib support optional. [jone]
 
 
 1.3.1 (2019-02-21)

--- a/src/collective/z3cform/datagridfield/static/datagridfield.js
+++ b/src/collective/z3cform/datagridfield/static/datagridfield.js
@@ -176,8 +176,10 @@ jQuery(function($) {
         .attr('class', function(i, cls) {
           return cls.replace(/dgw\-disabled-pat-/, 'pat-');
         });
-        var patRegistry = require('pat-registry');
-        patRegistry.scan(new_row);
+        if ( typeof require !== 'undefined' ) {
+          var patRegistry = require('pat-registry');
+          patRegistry.scan(new_row);
+        }
         return new_row;
     };
 


### PR DESCRIPTION
The Plone 4 version (1.3.x) did not work without require and patterns lib, although neither Plone 4 nor c.z.datagridfield installs patterns lib, nor is it documented in the readme.

This change simply makes the patterns lib support optional, so that it also work without patterns lib.