### PR TITLE
Bug fix: auto appending row

### DIFF
--- a/src/collective/z3cform/datagridfield/static/init_field.js
+++ b/src/collective/z3cform/datagridfield/static/init_field.js
@@ -1,6 +1,8 @@
-(function($) {
-  if (window.dataGridField2Functions) {
-    // hack for load datagrid stuff in overlay/modals
-    window.dataGridField2Functions.init();
-  }
-})(jQuery);
+require([
+    'jquery',
+    '++resource++collective.z3cform.datagridfield/datagridfield',
+], function ($) {
+    $(document).ready(function() {
+        window.dataGridField2Functions.init();
+    });
+})

--- a/src/collective/z3cform/datagridfield/tests/robot/test_autoappend.robot
+++ b/src/collective/z3cform/datagridfield/tests/robot/test_autoappend.robot
@@ -10,6 +10,8 @@ Resource  plone/app/robotframework/keywords.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
+Suite setup  Set Selenium speed  0.5s
+
 Test Setup  Open test browser
 Test Teardown  Close all browsers
 
@@ -17,13 +19,13 @@ Test Teardown  Close all browsers
 *** Test Cases ***************************************************************
 
 Scenario: Demo with two data rows plus empty row
-  Given the demo
-   Then two rows plus empty row are visible
+    Given the demo
+    Then two rows plus empty row are visible
 
 Scenario: Add only one row
-  Given the demo
-   When I enter a value for first field
-   Then one single row is added
+    Given the demo
+    When I enter a value for first field
+    Then one single row is added
 
 
 *** Keywords *****************************************************************
@@ -31,24 +33,27 @@ Scenario: Add only one row
 # --- Given ------------------------------------------------------------------
 
 the demo
-  Go To  ${PLONE_URL}/@@demo-collective.z3cform.datagrid
-  Wait until page contains  Simple Form
+    Go To  ${PLONE_URL}/@@demo-collective.z3cform.datagrid
+    Wait until page contains  Country
 
 
 # --- WHEN -------------------------------------------------------------------
 
 I enter a value for first field
-  Input Text  form-widgets-address-AA-widgets-line1  Chalet in the mountains
-  Input Text  form-widgets-address-AA-widgets-line2  Valais
+    Wait until element is visible
+    ...  id=form-widgets-address-2-widgets-line1
+    Input Text  form-widgets-address-2-widgets-line1  Chalet in the mountains
+    Input Text  form-widgets-address-2-widgets-line2  Valais
 
 
 # --- THEN -------------------------------------------------------------------
 
 two rows plus empty row are visible
-  Element Should Be Visible  id=form-widgets-address-0-widgets-line1
-  Element Should Be Visible  id=form-widgets-address-1-widgets-line1
-  Element Should Not Be Visible  id=form-widgets-address-2-widgets-line1
+    Element Should Be Visible  id=form-widgets-address-0-widgets-line1
+    Element Should Be Visible  id=form-widgets-address-1-widgets-line1
+    Element Should Be Visible  id=form-widgets-address-2-widgets-line1
+    Element Should Not Be Visible  id=form-widgets-address-3-widgets-line1
 
 one single row is added
-  Element Should Be Visible  id=form-widgets-address-AA-widgets-line1
-  Element Should Not Be Visible  id=form-widgets-address-4-widgets-line1
+    Element Should Be Visible  id=form-widgets-address-3-widgets-line1
+    Element Should Not Be Visible  id=form-widgets-address-4-widgets-line1


### PR DESCRIPTION
dataGridField2Functions.init() **after** DOM is loaded.
The call should stay in init_field.py for modals.
The setup is not elegant, but I do not change it as it works.  
Fixes issue https://github.com/collective/collective.z3cform.datagridfield/issues/92