### PR TITLE
Remove the ZCML registration for AutoExtensibleSubformAdapter.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove the ZCML registration for ``AutoExtensibleSubformAdapter``.  This
+  fixes `#114 <https://github.com/collective/collective.z3cform.datagridfield/issues/114>`_.
+  [batlock666]
 
 
 2.0.1 (2021-07-28)

--- a/src/collective/z3cform/datagridfield/configure.zcml
+++ b/src/collective/z3cform/datagridfield/configure.zcml
@@ -29,7 +29,6 @@
         />
   </class>
 
-  <adapter factory=".autoform.AutoExtensibleSubformAdapter" />
   <adapter factory=".autoform.MultipleErrorViewSnippetWithMessage" />
   <adapter factory=".datagridfield.GridDataConverter" />
   <adapter factory=".datagridfield.DataGridFieldSubformAdapter" />


### PR DESCRIPTION
This fixes https://github.com/collective/collective.z3cform.datagridfield/issues/114.