### PR TITLE
Fix implementation for sub form adapter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix sub form adapter implementation. `#114 <https://github.com/collective/collective.z3cform.datagridfield/issues/114>_`.
+  [thomasmassmann]
 
 
 2.0.1 (2021-07-28)

--- a/src/collective/z3cform/datagridfield/autoform.py
+++ b/src/collective/z3cform/datagridfield/autoform.py
@@ -10,13 +10,14 @@
 from plone.autoform.form import AutoExtensibleForm
 from plone.autoform.interfaces import IAutoExtensibleForm
 from z3c.form import action
-from z3c.form import form
 from z3c.form.error import MultipleErrorViewSnippet
 from z3c.form.interfaces import IFormLayer
 from z3c.form.interfaces import IMultipleErrors
 from z3c.form.interfaces import IObjectWidget
 from z3c.form.interfaces import ISubForm
 from z3c.form.interfaces import ISubformFactory
+from z3c.form.object import ObjectSubForm
+from z3c.form.object import SubformAdapter
 from zope.component import adapter
 from zope.i18nmessageid import Message
 from zope.interface import implementer
@@ -24,10 +25,18 @@ from zope.interface import Interface
 
 
 @implementer(ISubForm)
-class AutoExtensibleSubForm(AutoExtensibleForm, form.BaseForm):
+class AutoExtensibleSubForm(AutoExtensibleForm, ObjectSubForm):
+
     @property
     def schema(self):
         return self.__parent__.field.schema
+
+    def update(self):
+        # Ensure correct form mode is set
+        # If not, it will always be input
+        self.mode = self.__parent__.mode
+        super(AutoExtensibleSubForm, self).update()
+
 
     def updateActions(self):
         self.actions = action.Actions(self.__parent__, self.request, None)
@@ -50,7 +59,7 @@ class AutoExtensibleSubForm(AutoExtensibleForm, form.BaseForm):
     Interface,  # field.schema
 )
 @implementer(ISubformFactory)
-class AutoExtensibleSubformAdapter(object):
+class AutoExtensibleSubformAdapter(SubformAdapter):
     factory = AutoExtensibleSubForm
 
 


### PR DESCRIPTION
The sub form adapter needs a different signature than originally provided.

With those changes it is possible to have an `AutoExtensibleForm` as sub form in a data grid field.

This fixes #114.

There is another PR for this: #115. But I don’t think we should remove it.

@jensens, what’s your opinion on this?