### PR TITLE
Use latest bobtemplates.plone CI config, including Plone 6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,13 @@ jobs:
               run: |
                   tox -r -e black-check
 
+            - name: Lint check
+              run: |
+                  tox -r
+              env:
+                LINTER: lint
+                PYTHON-VERSION: ${{ matrix.python-version }}
+
             - name: Test with tox
               run: |
                   tox -r

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,10 +74,6 @@ jobs:
               run: |
                   tox -r -e black-check
 
-            - name: Lint check
-              run: |
-                  tox -r -e py${{ matrix.python-version }}-lint
-
             - name: Test with tox
               run: |
                   tox -r

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,23 +12,74 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: [3.8, 2.7]
+                plone-version:
+                    - 'Plone52'
+                    - 'Plone60'
+                python-version: [2.7, 3.7, 3.8, 3.9]
+                exclude:
+                    - plone-version: 'Plone52'
+                      python-version: 3.9
+                    - plone-version: 'Plone60'
+                      python-version: 2.7
+                    - plone-version: 'Plone60'
+                      python-version: 3.7
+                    - plone-version: 'Plone60'
+                      python-version: 3.8
 
         steps:
+            - uses: actions/setup-python@v2
+              with:
+                  python-version: '3.9'
+
             - uses: actions/checkout@v2
+
             - uses: actions/cache@v2
               with:
-                  path: ~/.cache/pip
-                  key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-                  restore-keys: |
-                    ${{ runner.os }}-pip-
+                  path: |
+                    ~/.cache/pip
+                    ~/buildout-cache
+                    ~/extends
+                  key: ${{ runner.os }}-tox-${{ matrix.python-version }}-${{ matrix.plone-version }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/*.cfg') }}-${{ hashFiles('**/constraints.txt') }}-${{ hashFiles('**/tox.ini') }}
+                #   restore-keys: |
+                #     ${{ runner.os }}-pip-
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v2
               with:
                   python-version: ${{ matrix.python-version }}
+
+            - name: Install system libraries
+              run: sudo apt-get install libxml2-dev libxslt1-dev libjpeg-dev
+
+            - name: setup buildout cache
+              run: |
+                  mkdir -p ~/buildout-cache/{eggs,downloads}
+                  mkdir ~/.buildout
+                  echo "[buildout]" > $HOME/.buildout/default.cfg
+                  echo "download-cache = $HOME/buildout-cache/downloads" >> $HOME/.buildout/default.cfg
+                  echo "eggs-directory = $HOME/buildout-cache/eggs" >> $HOME/.buildout/default.cfg
+
             - name: Install dependencies
               run: |
-                  sudo apt-get install libxml2-dev libxslt1-dev libjpeg-dev
-                  pip install flake8 tox tox-gh-actions
+                  python -m pip install --upgrade pip
+                  pip install tox tox-gh-actions
+
+            - name: Black-Check
+              run: |
+                  tox -r -e black-check
+
             - name: Test with tox
-              run: tox
+              run: |
+                  tox -r
+              env:
+                PLONE-VERSION: ${{ matrix.plone-version }}
+                PYTHON-VERSION: ${{ matrix.python-version }}
+
+            - name: Coverage report on python3.7
+              run: tox -r -e coverage-report
+              if: ${{matrix.python-version == '3.7'}}
+
+            - name: "Upload coverage to Codecov"
+              uses: "codecov/codecov-action@v1"
+              with:
+                fail_ci_if_error: true
+              if: ${{matrix.python-version == '3.7'}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,10 +76,7 @@ jobs:
 
             - name: Lint check
               run: |
-                  tox -r
-              env:
-                LINTER: lint
-                PYTHON-VERSION: ${{ matrix.python-version }}
+                  tox -r -e py${{ matrix.python-version }}-lint
 
             - name: Test with tox
               run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,6 @@ jobs:
                       python-version: 3.9
                     - plone-version: 'Plone60'
                       python-version: 2.7
-                    - plone-version: 'Plone60'
-                      python-version: 3.7
-                    - plone-version: 'Plone60'
-                      python-version: 3.8
 
         steps:
             - uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,17 @@ jobs:
             fail-fast: false
             matrix:
                 plone-version:
+                    - 'Plone51'
                     - 'Plone52'
                     - 'Plone60'
                 python-version: [2.7, 3.7, 3.8, 3.9]
                 exclude:
+                    - plone-version: 'Plone51'
+                      python-version: 3.7
+                    - plone-version: 'Plone51'
+                      python-version: 3.8
+                    - plone-version: 'Plone51'
+                      python-version: 3.9
                     - plone-version: 'Plone52'
                       python-version: 3.9
                     - plone-version: 'Plone60'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use latest config for Github Actions and tox. Add Plone 6 related ci and tox config.
+  [thomasmassmann]
 
 
 2.0.1 (2021-07-28)

--- a/constraints_plone60.txt
+++ b/constraints_plone60.txt
@@ -1,0 +1,15 @@
+-c https://dist.plone.org/release/6.0-dev/requirements.txt
+
+#setuptools==54.0.0
+#zc.buildout==3.0.0b2
+#pip==21.0.1
+#
+## Windows specific down here (has to be installed here, fails in buildout)
+## Dependency of zope.sendmail:
+#pywin32 ; platform_system == 'Windows'
+#
+## SSL Certs on windows, because Python is missing them otherwise:
+#certifi ; platform_system == 'Windows'
+
+isort>=5
+black==21.6b0

--- a/requirements_plone51.txt
+++ b/requirements_plone51.txt
@@ -1,0 +1,3 @@
+-c constraints_plone51.txt
+setuptools
+zc.buildout

--- a/requirements_plone52.txt
+++ b/requirements_plone52.txt
@@ -1,0 +1,3 @@
+-c constraints_plone52.txt
+setuptools
+zc.buildout

--- a/requirements_plone60.txt
+++ b/requirements_plone60.txt
@@ -1,0 +1,3 @@
+-c constraints_plone60.txt
+setuptools
+zc.buildout

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,16 +68,10 @@ ignore =
 
 [isort]
 # black compatible isort rules:
+profile = black
 force_alphabetical_sort = True
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses = True
+force_single_line = True
 lines_after_imports = 2
-line_length = 89
-not_skip =
-    __init__.py
-skip =
 
 [flake8]
 # black compatible flake8 rules:

--- a/test_plone60.cfg
+++ b/test_plone60.cfg
@@ -1,0 +1,12 @@
+[buildout]
+
+extends =
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-6.0.x.cfg
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
+    base.cfg
+
+update-versions-file = test_plone60.cfg
+
+[versions]
+createcoverage = 1.5
+watchdog = 2.1.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,32 @@
 [tox]
 envlist =
     py27-lint,
+    py37-lint,
     py38-lint,
+    black-check,
     py{27}-Plone{51},
-    py{27,38}-Plone{52},
+    py{27,37,38}-Plone{52},
+    py{39}-Plone{60},
 #    build_instance,
 #    docs,
 #    coverage-report,
 
 skip_missing_interpreters = True
+
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+
+
+[gh-actions:env]
+PLONE-VERSION =
+    Plone52: Plone52
+    Plone60: Plone60
+
 
 [testenv]
 skip_install = true
@@ -25,21 +43,25 @@ commands =
 
 setenv =
     COVERAGE_FILE=.coverage.{envname}
-    version_file=test_plone52.cfg
+    # version_file=test_plone52.cfg
     Plone51: version_file=test_plone51.cfg
     Plone52: version_file=test_plone52.cfg
+    Plone60: version_file=test_plone60.cfg
 
 deps =
-    -rrequirements.txt
+    Plone51: -rrequirements_plone51.txt
     Plone51: -cconstraints_plone51.txt
+    Plone52: -rrequirements_plone52.txt
     Plone52: -cconstraints_plone52.txt
+    Plone60: -rrequirements_plone60.txt
+    Plone60: -cconstraints_plone60.txt
     coverage
 
 
 [testenv:coverage-report]
 skip_install = true
 usedevelop = True
-basepython = python3.8
+basepython = python3.7
 
 deps =
     coverage
@@ -60,7 +82,8 @@ commands =
 skip_install = true
 
 deps =
-    isort<5
+    -cconstraints.txt
+    isort
     flake8
     # helper to generate HTML reports:
     flake8-html
@@ -86,24 +109,57 @@ deps =
 
 commands =
     mkdir -p {toxinidir}/reports/flake8
-    - flake8 --format=html --htmldir={toxinidir}/reports/flake8 --doctests src setup.py
-    flake8 --doctests src setup.py
-    isort --check-only --recursive {toxinidir}/src
+    - flake8 --format=html --htmldir={toxinidir}/reports/flake8 --doctests {toxinidir}/src {toxinidir}/setup.py
+    flake8 --doctests {toxinidir}/src {toxinidir}/setup.py
+    isort --check-only {toxinidir}/src {toxinidir}/setup.py
 
 whitelist_externals =
     mkdir
+
 
 [testenv:isort-apply]
 skip_install = true
 
 deps =
-    isort<5
+    -cconstraints.txt
+    isort
 
 commands =
-    isort --recursive --apply {toxinidir}/src
+    isort {toxinidir}/src {toxinidir}/setup.py
+
+
+[testenv:black-check]
+basepython = python3.9
+skip_install = True
+deps =
+    -cconstraints.txt
+    black
+
+commands =
+    black --check --diff -v src setup.py
+
+
+[testenv:black-enforce]
+basepython = python3.9
+skip_install = True
+deps =
+    -cconstraints.txt
+    black
+
+commands =
+    black -v src setup.py
+
 
 [testenv:py27-lint]
 basepython = python2.7
+skip_install = true
+deps = {[lint]deps}
+commands = {[lint]commands}
+whitelist_externals = {[lint]whitelist_externals}
+
+
+[testenv:py37-lint]
+basepython = python3.7
 skip_install = true
 deps = {[lint]deps}
 commands = {[lint]commands}
@@ -116,6 +172,15 @@ skip_install = true
 deps = {[lint]deps}
 commands = {[lint]commands}
 whitelist_externals = {[lint]whitelist_externals}
+
+
+[testenv:py39-lint]
+basepython = python3.9
+skip_install = true
+deps = {[lint]deps}
+commands = {[lint]commands}
+whitelist_externals = {[lint]whitelist_externals}
+
 
 [testenv:docs]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 envlist =
-    py27-lint,
-    py37-lint,
-    py38-lint,
+    py{27,37,38,39}-lint,
     black-check,
     py{27}-Plone{51},
     py{27,37,38}-Plone{52},

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ python =
 
 [gh-actions:env]
 PLONE-VERSION =
+    Plone51: Plone51
     Plone52: Plone52
     Plone60: Plone60
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,6 @@ envlist =
     py{27}-Plone{51},
     py{27,37,38}-Plone{52},
     py{39}-Plone{60},
-#    build_instance,
-#    docs,
-#    coverage-report,
 
 skip_missing_interpreters = True
 
@@ -25,8 +22,6 @@ PLONE-VERSION =
     Plone51: Plone51
     Plone52: Plone52
     Plone60: Plone60
-LINTER =
-    lint: lint
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,8 @@ PLONE-VERSION =
     Plone51: Plone51
     Plone52: Plone52
     Plone60: Plone60
+LINTER =
+    lint: lint
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     black-check,
     py{27}-Plone{51},
     py{27,37,38}-Plone{52},
-    py{39}-Plone{60},
+    py{37,38,39}-Plone{60},
 
 skip_missing_interpreters = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ python =
 [gh-actions:env]
 PLONE-VERSION =
     Plone51: Plone51
-    Plone52: Plone52
+    Plone52: Plone52,lint
     Plone60: Plone60
 
 


### PR DESCRIPTION
- Use latest bobtemplates.plone config for Github Actions and tox
- Add Plone 6 related ci and tox config