### PR TITLE
Treat int columns in the right way

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Treat the int columnts in the right way by deserializer.
+  [foxtrot-dfm1]
 
 
 3.0.0 (2022-09-28)

--- a/src/collective/z3cform/datagridfield/row.py
+++ b/src/collective/z3cform/datagridfield/row.py
@@ -20,6 +20,7 @@ from zope.schema import Object
 from zope.schema.interfaces import IChoice
 from zope.schema.interfaces import WrongContainedType
 from zope.security.interfaces import IPermission
+from zope.schema.interfaces import IFromUnicode
 
 
 @implementer(IRow)
@@ -58,6 +59,10 @@ class DictRow(Object):
                 bound = field_type.bind(self.context)
                 bound.validate(value[field_name])
             else:
+                if isinstance(value[field_name], str):
+                    value[field_name] = IFromUnicode(field).fromUnicode(
+                        value[field_name]
+                    )
                 field_type.validate(value[field_name])
 
     def set(self, object, value):


### PR DESCRIPTION
Deserializer can’t t convert the int fields, so I used the plone.restapi convert technique to solve the problem