### PR TITLE
Make sure the dataconverter doesn't change the original data itself 

### DIFF
--- a/src/collective/z3cform/datagridfield/datagridfield.py
+++ b/src/collective/z3cform/datagridfield/datagridfield.py
@@ -239,13 +239,7 @@ class DataGridFieldObjectWidget(AutoFields, ObjectWidget):
                     continue
                 widget = self.widgets[name]
                 widget_value = widget.value
-                try:
-                    # XXX: Since the new DictRowConverter this try/catch
-                    # should not be necessary anymore
-                    converter = interfaces.IDataConverter(widget)
-                    value[name] = converter.toFieldValue(widget_value)
-                except (FormatterValidationError, ValidationError, ValueError):
-                    value[name] = widget_value
+                value[name] = widget_value
         return value
 
     @value.setter
@@ -268,13 +262,7 @@ class DataGridFieldObjectWidget(AutoFields, ObjectWidget):
                 if v is NO_VALUE:
                     continue
                 widget = self.widgets[name]
-                try:
-                    # XXX: Since the new DictRowConverter this try/catch
-                    # should not be necessary anymore
-                    converter = interfaces.IDataConverter(widget)
-                    widget.value = converter.toWidgetValue(v)
-                except (AttributeError, TypeError) as msg:
-                    widget.value = v
+                widget.value = v
 
     def updateWidgets(self, *args, **kwargs):
         super().updateWidgets(*args, **kwargs)

--- a/src/collective/z3cform/datagridfield/datagridfield.py
+++ b/src/collective/z3cform/datagridfield/datagridfield.py
@@ -230,7 +230,7 @@ class DataGridFieldObjectWidget(AutoFields, ObjectWidget):
         # value (get) cannot raise an exception, then we return
         # insane values
         try:
-            value = self.extract()
+            return self.extract()
         except MultipleErrors:
             value = {}
             active_names = self.fields.keys()
@@ -238,9 +238,8 @@ class DataGridFieldObjectWidget(AutoFields, ObjectWidget):
                 if name not in active_names:
                     continue
                 widget = self.widgets[name]
-                widget_value = widget.value
-                value[name] = widget_value
-        return value
+                value[name] = widget.value
+            return value
 
     @value.setter
     def value(self, value):

--- a/src/collective/z3cform/datagridfield/row.py
+++ b/src/collective/z3cform/datagridfield/row.py
@@ -70,26 +70,28 @@ class DictRowConverter(BaseDataConverter):
     # convert the columns to their field/widget value
 
     def toFieldValue(self, value):
+        _converted = {}
         for name, fld in self.field.schema.namesAndDescriptions():
             converter = self._getConverter(fld)
             try:
-                value[name] = converter.toFieldValue(value[name])
-            except Exception:
+                _converted[name] = converter.toFieldValue(value[name])
+            except Exception as msg:
                 # XXX: catch exception here in order to not break
                 # versions prior to this fieldValue converter
-                pass
-        return value
+                _converted[name] = value[name]
+        return _converted
 
     def toWidgetValue(self, value):
+        _converted = {}
         for name, fld in self.field.schema.namesAndDescriptions():
             converter = self._getConverter(fld)
             try:
-                value[name] = converter.toWidgetValue(value[name])
-            except Exception:
+                _converted[name] = converter.toWidgetValue(value[name])
+            except Exception as msg:
                 # XXX: catch exception here in order to not break
                 # versions prior to this widgetValue converter
-                pass
-        return value
+                _converted[name] = value[name]
+        return _converted
 
 
 @adapter(IDexterityContent)


### PR DESCRIPTION
This PR fixes the `DictRowConverter` to correctly convert between field/widget values inside the `DictRow`schema ... however this will likely break your code if you rely on the "unconverted" data of special fields like `schema.Bool`, `schema.Date` or `RelationChoiceField` etc. Before this converter the saved data of this example schema looked like this:

```
class IMembers(model.Schema):

    member = RelationChoice(
        title=_("Member"),
        vocabulary="plone.app.vocabularies.Catalog",
        required=False,
    )
    directives.widget(
        "member",
        RelatedItemsFieldWidget,
    )

    success = schema.Bool(
        title=_("Exam successfully passed"),
        required=False,
        default=False,
    )

class IExampleSchema(model.Schema):
    members = schema.List(
        title=_("Course Members"),
        value_type=DictRow(
            title="Member",
            schema=IMembers,
        ),
        required=False,
    )
    directives.widget(
        "members",
        DataGridFieldWidgetFactory,
        input_table_css_class="table table-sm",
        display_table_css_class="table table-sm",
    )
```

old saved data
```
[
    {'member': '6f40b7bf64d747278b03e80aef019a23', 'success': ()},
    {'member': '881a34e97e06428ab93dd350110beb7f', 'success': ()},
    ...
]
```

now the converter converts each column correctly to
```
[
    {'member': <Member at /Plone/members/0434df4829afcc1aeb27055bb9040f47>, 'success': False},
    {'member': <Member at /Plone/members/297b2d405bf998ea6e6e465024164815>, 'success': False},
    ...
]
```

I'd like to get some feedback of people using this package /cc @fredvd @maurits @laulaz 

In my case I simply hit edit/save in the content items because the edit form converts safely from the olddata to the new. But if you have a lot of items you might want to have a migration view which iters all the items and schemas and calls a `DictRowConverter.toFieldValue(old_val)` on all datagridfields ... or just document it somewhere for the developers out there what to do if they want to update.