### PR TITLE
Add missing package name in setup.py.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 include *.py
 include *.rst
 include *.txt
-include setup.cfg
 include Makefile
 include package.json
 include webpack.config.js

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ version = "3.0.3.dev0"
 
 
 setup(
+    name="collective.z3cform.datagridfield",
     # zest.releaser needs version here for now
     version=version,
     description="Fields with repeatable data grid (table-like) for z3.cform",


### PR DESCRIPTION
This got lost in PR #173 when moving stuff over from setup.cfg to setup.py. I am surprised the tests passed.

Effects this had:
* Checking out the package with mr.developer did not work: the latest PyPI release was used.
* So I tried creating an internal release to see if I could use that version. The source distribution ended up as a file named `collective-3.0.3.dev0+zest0.tar.gz`.