### PR TITLE
Fix missing `plone.autoform` ExportImportHandler

### DIFF
--- a/news/188.bugfix
+++ b/news/188.bugfix
@@ -1,0 +1,2 @@
+Add missing `plone.autoform` exportimport handler.
+[petschki]

--- a/src/collective/z3cform/datagridfield/autoform.py
+++ b/src/collective/z3cform/datagridfield/autoform.py
@@ -6,6 +6,7 @@
     Adds subform support for plone.autoform.
 
 """
+
 from lxml import etree
 from plone.autoform.interfaces import IAutoExtensibleForm
 from plone.autoform.widgets import WidgetExportImportHandler
@@ -44,7 +45,13 @@ class DGFExportImportHandler(WidgetExportImportHandler):
             # translate boolean values
             for node in widgetNode.iterchildren():
                 if noNS(node.tag) == attributeName:
-                    params[attributeName] = node.text.lower() in ("y", "yes", "true", "on", "1")
+                    params[attributeName] = node.text.lower() in (
+                        "y",
+                        "yes",
+                        "true",
+                        "on",
+                        "1",
+                    )
 
         for attributeName in (
             "display_table_css_class",

--- a/src/collective/z3cform/datagridfield/autoform.py
+++ b/src/collective/z3cform/datagridfield/autoform.py
@@ -6,8 +6,11 @@
     Adds subform support for plone.autoform.
 
 """
-
+from lxml import etree
 from plone.autoform.interfaces import IAutoExtensibleForm
+from plone.autoform.widgets import WidgetExportImportHandler
+from plone.supermodel.utils import noNS
+from z3c.form.browser.interfaces import IHTMLFormElement
 from z3c.form.error import MultipleErrorViewSnippet
 from z3c.form.interfaces import IMultipleErrors
 from zope.component import adapter
@@ -24,3 +27,46 @@ from zope.i18nmessageid import Message
 class MultipleErrorViewSnippetWithMessage(MultipleErrorViewSnippet):
     def render(self):
         return Message("There were some errors.", domain="z3c.form")
+
+
+class DGFExportImportHandler(WidgetExportImportHandler):
+    # XML exportimport handler for DataGridFieldWidget
+
+    def read(self, widgetNode, params):
+        super().read(widgetNode, params)
+        # we simply add DGF widget attributes here
+        for attributeName in (
+            "allow_insert",
+            "allow_delete",
+            "allow_reorder",
+            "auto_append",
+        ):
+            # translate boolean values
+            for node in widgetNode.iterchildren():
+                if noNS(node.tag) == attributeName:
+                    params[attributeName] = node.text.lower() in ("y", "yes", "true", "on", "1")
+
+        for attributeName in (
+            "display_table_css_class",
+            "input_table_css_class",
+        ):
+            for node in widgetNode.iterchildren():
+                if noNS(node.tag) == attributeName:
+                    params[attributeName] = node.text
+
+    def write(self, widgetNode, params):
+        super().write(widgetNode, params)
+        for attributeName in (
+            "allow_insert",
+            "allow_delete",
+            "allow_reorder",
+            "auto_append",
+            "display_table_css_class",
+            "input_table_css_class",
+        ):
+            child = etree.Element(attributeName)
+            child.text = params.get(attributeName, "")
+            widgetNode.append(child)
+
+
+DGFExportImportHandlerFactory = DGFExportImportHandler(IHTMLFormElement)

--- a/src/collective/z3cform/datagridfield/configure.zcml
+++ b/src/collective/z3cform/datagridfield/configure.zcml
@@ -90,6 +90,11 @@
         name="collective.z3cform.datagridfield.row.DictRow"
         component=".supermodel.DictRowHandler"
         />
+    <utility
+        provides="plone.autoform.interfaces.IWidgetExportImportHandler"
+        name="collective.z3cform.datagridfield.datagridfield.DataGridFieldWidgetFactory"
+        component=".autoform.DGFExportImportHandlerFactory"
+        />
   </configure>
 
   <configure zcml:condition="installed plone.restapi">

--- a/src/collective/z3cform/datagridfield/demo/dgftest.xml
+++ b/src/collective/z3cform/datagridfield/demo/dgftest.xml
@@ -6,8 +6,7 @@
        i18n:domain="collective.z3cform.datagridfield"
 >
   <schema>
-    <field form:widget="collective.z3cform.datagridfield.datagridfield.DataGridFieldWidgetFactory"
-           name="table"
+    <field name="table"
            type="zope.schema.List"
     >
       <title>Tabular Field</title>
@@ -15,6 +14,10 @@
       <value_type type="collective.z3cform.datagridfield.row.DictRow">
         <schema>collective.z3cform.datagridfield.demo.interfaces.ITableRow</schema>
       </value_type>
+      <form:widget type="collective.z3cform.datagridfield.datagridfield.DataGridFieldWidgetFactory">
+        <allow_reorder>True</allow_reorder>
+        <auto_append>False</auto_append>
+      </form:widget>
     </field>
   </schema>
 </model>


### PR DESCRIPTION
With this you can customize widget attributes inside the `<form:widget />` node ... 

```XML
<?xml version="1.0" encoding="utf-8"?>
<model xmlns="http://namespaces.plone.org/supermodel/schema"
       xmlns:form="http://namespaces.plone.org/supermodel/form"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       xmlns:security="http://namespaces.plone.org/supermodel/security"
       i18n:domain="collective.z3cform.datagridfield"
>
  <schema>
    <field name="table"
           type="zope.schema.List"
    >
      <title>Tabular Field</title>
      <description />
      <value_type type="collective.z3cform.datagridfield.row.DictRow">
        <schema>collective.z3cform.datagridfield.demo.interfaces.ITableRow</schema>
      </value_type>
      <form:widget type="collective.z3cform.datagridfield.datagridfield.DataGridFieldWidgetFactory">
        <allow_reorder>True</allow_reorder>
        <auto_append>False</auto_append>
      </form:widget>
    </field>
  </schema>
</model>

```
