### PR TITLE
Fixes for deserializer

### DIFF
--- a/news/206.bugfix
+++ b/news/206.bugfix
@@ -1,0 +1,4 @@
+do not skip None value fields because this leads to "ConstraintNotSatified" errors in validator. @petschki
+
+generalize lookup of customized deserializer for IRow. @petschki
+


### PR DESCRIPTION
- do not skip None value fields because this leads to "ConstraintNotSatified" errors in validator
- generalize lookup of customized deserializer for IRow