### PR TITLE
Add missing widget converters and `NO_VALUE` pickling errors.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 #
 # EditorConfig Configuration file, for more details see:

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [flake8]
 doctests = 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 version: 2
 updates:

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -1,16 +1,10 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 name: Meta
+
 on:
   push:
-    branches:
-      - master
-      - main
-  pull_request:
-    branches:
-      - master
-      - main
   workflow_dispatch:
 
 ##

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -1,10 +1,11 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 name: Tests
 
 on:
   push:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -29,11 +30,15 @@ jobs:
     - uses: actions/checkout@v6
       with:
         persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@v6
+    - name: Install uv + caching
+      uses: astral-sh/setup-uv@v8.0.0
       with:
+        enable-cache: true
+        cache-dependency-glob: |
+          setup.*
+          tox.ini
+          pyproject.toml
         python-version: ${{ matrix.config[0] }}
-        allow-prereleases: true
 
 ##
 # Add extra configuration options in .meta.toml:
@@ -42,25 +47,13 @@ jobs:
 #  _your own configuration lines_
 #  """
 ##
-    - name: Pip cache
-      uses: actions/cache@v5
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ matrix.config[0] }}-
-          ${{ runner.os }}-pip-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox
     - name: Initialize tox
       # the bash one-liner below does not work on Windows
       if: contains(matrix.os, 'ubuntu')
       run: |
-        if [ `tox list --no-desc -f init|wc -l` = 1 ]; then tox -e init;else true; fi
+        if [ `uvx tox list --no-desc -f init|wc -l` = 1 ]; then uvx --with tox-uv tox -e init;else true; fi
     - name: Test
-      run: tox -e ${{ matrix.config[2] }}
+      run: uvx --with tox-uv tox -e ${{ matrix.config[2] }}
 
 
 ##

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 # python related
 *.egg-info

--- a/.meta.toml
+++ b/.meta.toml
@@ -1,9 +1,9 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "2.3.1"
+commit-id = "2.8.0"
 
 [pyproject]
 codespell_skip = "*.js,*.min.js,*.min.js.map,*.css.map,yarn.lock,robot_*,test_*"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 ci:
     autofix_prs: false
@@ -10,13 +10,13 @@ repos:
     rev: v3.21.2
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
+        args: [--py310-plus]
 -   repo: https://github.com/pycqa/isort
-    rev: 7.0.0
+    rev: 8.0.1
     hooks:
     -   id: isort
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.11.0
+    rev: 26.3.1
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty
@@ -44,7 +44,7 @@ repos:
 #  """
 ##
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
     -   id: codespell
         additional_dependencies:
@@ -62,14 +62,14 @@ repos:
     hooks:
     -   id: check-manifest
 -   repo: https://github.com/regebro/pyroma
-    rev: "5.0"
+    rev: "5.0.1"
     hooks:
     -   id: pyroma
 -   repo: https://github.com/mgedmin/check-python-versions
     rev: "0.24.0"
     hooks:
     -   id: check-python-versions
-        args: ['--only', 'setup.py,pyproject.toml']
+        args: ['--only', 'setup.py,tox.ini']
 -   repo: https://github.com/collective/i18ndude
     rev: "6.3.0"
     hooks:

--- a/news/+widget_converters.bugfix
+++ b/news/+widget_converters.bugfix
@@ -1,0 +1,16 @@
+Fix pickling errors when using ``LinkFieldWidget``, ``RelationList``, or
+``RelationChoice`` fields inside a ``DictRow`` schema:
+
+- ``NO_VALUE`` sentinels returned by widgets (e.g. ``LinkWidget``) for empty
+  fields are now mapped to ``missing_value`` instead of being stored
+  persistently, preventing ``_pickle.PicklingError``.
+- Acquisition-wrapped content objects returned by
+  ``ContentBrowserDataConverter`` for relation fields are now unwrapped via
+  ``aq_base()`` before storage, preventing
+  ``TypeError: Can't pickle objects in acquisition wrappers``.
+- ``DictRowConverter.toWidgetValue`` now looks up the converter for the
+  *actual* sub-widget (e.g. ``LinkWidget``) instead of always falling back to
+  the default widget, so custom converters like ``LinkWidgetDataConverter``
+  are correctly used when re-editing a saved row.
+
+@petschki

--- a/news/+widget_converters.bugfix
+++ b/news/+widget_converters.bugfix
@@ -1,5 +1,6 @@
-Fix pickling errors when using ``LinkFieldWidget``, ``RelationList``, or
-``RelationChoice`` fields inside a ``DictRow`` schema:
+Fix pickling errors and data-loss issues when using ``LinkFieldWidget``,
+``RelationList``, ``RelationChoice``, or ``NamedBlobImage`` fields inside a
+``DictRow`` schema:
 
 - ``NO_VALUE`` sentinels returned by widgets (e.g. ``LinkWidget``) for empty
   fields are now mapped to ``missing_value`` instead of being stored
@@ -8,9 +9,16 @@ Fix pickling errors when using ``LinkFieldWidget``, ``RelationList``, or
   ``ContentBrowserDataConverter`` for relation fields are now unwrapped via
   ``aq_base()`` before storage, preventing
   ``TypeError: Can't pickle objects in acquisition wrappers``.
-- ``DictRowConverter.toWidgetValue`` now looks up the converter for the
-  *actual* sub-widget (e.g. ``LinkWidget``) instead of always falling back to
-  the default widget, so custom converters like ``LinkWidgetDataConverter``
-  are correctly used when re-editing a saved row.
+- ``DictRowConverter.toFieldValue`` and ``toWidgetValue`` now look up the
+  converter for the *actual* sub-widget (e.g. ``LinkWidget``,
+  ``NamedImageWidget``) instead of always falling back to the default widget.
+  This fixes ``LinkWidget`` not being pre-populated on re-edit, and fixes
+  ``NamedBlobImage`` values being erased on the second save (the widget's
+  ``nochange`` action was never detected because the default widget had no
+  name). ``NOT_CHANGED`` returned by the namedfile converter is now correctly
+  resolved to the previously stored value.
+- Implement new ``DataGridFieldConverter`` to enable complex column widget
+  converters like ``NamedDataConverter`` which depends on already uploaded
+  data when no change is made during editing.
 
 @petschki

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [build-system]
-requires = ["setuptools>=68.2,<80", "wheel"]
+requires = ["setuptools>=68.2,<83", "wheel"]
+
+
 
 [tool.towncrier]
 directory = "news/"
@@ -60,7 +62,7 @@ profile = "plone"
 ##
 
 [tool.black]
-target-version = ["py38"]
+target-version = ["py310"]
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import setup
 
-
 version = "4.0.1.dev0"
 
 

--- a/src/collective/z3cform/datagridfield/__init__.py
+++ b/src/collective/z3cform/datagridfield/__init__.py
@@ -1,4 +1,3 @@
 from zope.i18nmessageid import MessageFactory
 
-
 _ = MessageFactory("collective.z3cform.datagridfield")

--- a/src/collective/z3cform/datagridfield/autoform.py
+++ b/src/collective/z3cform/datagridfield/autoform.py
@@ -17,7 +17,6 @@ from z3c.form.interfaces import IMultipleErrors
 from zope.component import adapter
 from zope.i18nmessageid import Message
 
-
 # XXX: The following controversial and may have side effects.
 # Its only purpose is to hide redundant error messages. Every
 # error within a subform seem to be rendered both for

--- a/src/collective/z3cform/datagridfield/configure.zcml
+++ b/src/collective/z3cform/datagridfield/configure.zcml
@@ -41,6 +41,7 @@
 
   <adapter factory=".autoform.MultipleErrorViewSnippetWithMessage" />
   <adapter factory=".datagridfield.DataGridValidator" />
+  <adapter factory=".datagridfield.DataGridFieldConverter" />
   <adapter factory=".row.DictRowConverter" />
 
   <adapter

--- a/src/collective/z3cform/datagridfield/datagridfield.py
+++ b/src/collective/z3cform/datagridfield/datagridfield.py
@@ -211,9 +211,7 @@ class DataGridFieldWidget(MultiWidget):
         if self.ignoreContext:
             return None
         try:
-            dm = getMultiAdapter(
-                (self.context, self.field), interfaces.IDataManager
-            )
+            dm = getMultiAdapter((self.context, self.field), interfaces.IDataManager)
             stored = dm.query()
         except Exception:
             return None
@@ -268,9 +266,7 @@ class DataGridFieldConverter(BaseDataConverter):
             row_widget = row_widgets[idx] if idx < len(row_widgets) else None
             converter = None
             if row_widget is not None:
-                converter = queryMultiAdapter(
-                    (value_type, row_widget), IDataConverter
-                )
+                converter = queryMultiAdapter((value_type, row_widget), IDataConverter)
             if converter is None:
                 converter = self._getConverter(value_type)
             result.append(converter.toWidgetValue(item))
@@ -296,9 +292,7 @@ class DataGridFieldConverter(BaseDataConverter):
             else:
                 # New row appended via the browser - no stored value.
                 row_widget = self.widget.getWidget(idx)
-            converter = queryMultiAdapter(
-                (value_type, row_widget), IDataConverter
-            )
+            converter = queryMultiAdapter((value_type, row_widget), IDataConverter)
             if converter is None:
                 converter = self._getConverter(value_type)
             converted.append(converter.toFieldValue(row_value))

--- a/src/collective/z3cform/datagridfield/datagridfield.py
+++ b/src/collective/z3cform/datagridfield/datagridfield.py
@@ -10,7 +10,9 @@ from plone.autoform.interfaces import MODES_KEY
 from z3c.form import interfaces
 from z3c.form.browser.multi import MultiWidget
 from z3c.form.browser.object import ObjectWidget
+from z3c.form.converter import BaseDataConverter
 from z3c.form.error import MultipleErrors
+from z3c.form.interfaces import IDataConverter
 from z3c.form.interfaces import IFormLayer
 from z3c.form.interfaces import INPUT_MODE
 from z3c.form.interfaces import IOrderedSelectWidget
@@ -20,6 +22,7 @@ from z3c.form.validator import SimpleFieldValidator
 from z3c.form.widget import FieldWidget
 from zope.component import adapter
 from zope.component import getMultiAdapter
+from zope.component import queryMultiAdapter
 from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.interface import Interface
@@ -120,6 +123,18 @@ class DataGridFieldWidget(MultiWidget):
             widget.form = self.form
             widget.parentForm = self.form
             alsoProvides(widget, interfaces.IFormAware)
+        # Give the row widget access to the pre-POST stored row value.
+        # Needed so DictRowConverter.toFieldValue can restore values for
+        # sub-converters that return NOT_CHANGED (e.g. NamedDataConverter
+        # on action=nochange). The stored row is otherwise inaccessible
+        # during the POST extraction cycle because ObjectWidget forces
+        # its subform to ignoreContext=True.
+        stored_row = None
+        if isinstance(idx, int):
+            stored_rows = self._get_stored_rows()
+            if stored_rows is not None and 0 <= idx < len(stored_rows):
+                stored_row = stored_rows[idx]
+        widget._stored_row = stored_row
         widget.update()
         return widget
 
@@ -182,6 +197,33 @@ class DataGridFieldWidget(MultiWidget):
         else:
             return not name.endswith("AA") and not name.endswith("TT")
 
+    def _get_stored_rows(self):
+        """Return the list of rows currently stored on the context.
+
+        This is used to give row widgets access to the pre-POST stored
+        values. Required so that sub-widgets like NamedFileWidget can
+        honor the ``action=nochange`` marker by returning the previously
+        stored value for fields where the user did not upload a new file.
+
+        Returns ``None`` when no reliable stored value can be obtained
+        (e.g. during an add form with no context yet).
+        """
+        if self.ignoreContext:
+            return None
+        try:
+            dm = getMultiAdapter(
+                (self.context, self.field), interfaces.IDataManager
+            )
+            stored = dm.query()
+        except Exception:
+            return None
+        if stored in (NO_VALUE, None):
+            return None
+        try:
+            return list(stored)
+        except TypeError:
+            return None
+
 
 @adapter(IField, IFormLayer)
 @implementer(interfaces.IFieldWidget)
@@ -192,6 +234,79 @@ def DataGridFieldWidgetFactory(field, request):
 
 # BBB
 DataGridFieldFactory = DataGridFieldWidgetFactory
+
+
+@adapter(IList, IDataGridFieldWidget)
+@implementer(IDataConverter)
+class DataGridFieldConverter(BaseDataConverter):
+    """Data converter for DataGridFieldWidget.
+
+    The built-in :class:`z3c.form.converter.MultiConverter` builds a fresh,
+    unbound row widget on every ``toFieldValue`` call (via
+    ``_getConverter(value_type)``). This prevents the per-row
+    :class:`DictRowConverter` from accessing any state that was attached to
+    the real row widgets during form ``update()`` - most notably the
+    pre-POST stored row value required to resolve ``NOT_CHANGED`` results
+    from sub-converters (e.g. ``NamedDataConverter`` on
+    ``action=nochange``).
+
+    This converter dispatches to the actual row widgets of the
+    :class:`DataGridFieldWidget` so that per-row conversion has full access
+    to the row widget and its stamped ``_stored_row`` attribute.
+    """
+
+    def toWidgetValue(self, value):
+        if value is self.field.missing_value:
+            return []
+        # Dispatch each stored row through a row-widget-aware converter
+        # when possible so that custom sub-widgets (e.g. LinkFieldWidget,
+        # NamedImageWidget) get their own registered converters.
+        result = []
+        row_widgets = list(getattr(self.widget, "widgets", []) or [])
+        value_type = self.field.value_type
+        for idx, item in enumerate(value):
+            row_widget = row_widgets[idx] if idx < len(row_widgets) else None
+            converter = None
+            if row_widget is not None:
+                converter = queryMultiAdapter(
+                    (value_type, row_widget), IDataConverter
+                )
+            if converter is None:
+                converter = self._getConverter(value_type)
+            result.append(converter.toWidgetValue(item))
+        return result
+
+    def toFieldValue(self, value):
+        if not len(value):
+            return self.field.missing_value
+
+        value_type = self.field.value_type
+        # Use the actual row widgets set up during form ``updateWidgets``.
+        # They carry the pre-POST stored row value (``_stored_row``) that
+        # sub-converters may need to resolve ``NOT_CHANGED`` markers.
+        real_rows = [
+            w
+            for w in (self.widget.widgets or [])
+            if not (w.id.endswith("AA") or w.id.endswith("TT"))
+        ]
+        converted = []
+        for idx, row_value in enumerate(value):
+            if idx < len(real_rows):
+                row_widget = real_rows[idx]
+            else:
+                # New row appended via the browser - no stored value.
+                row_widget = self.widget.getWidget(idx)
+            converter = queryMultiAdapter(
+                (value_type, row_widget), IDataConverter
+            )
+            if converter is None:
+                converter = self._getConverter(value_type)
+            converted.append(converter.toFieldValue(row_value))
+
+        collection_type = self.field._type
+        if isinstance(collection_type, tuple):
+            collection_type = collection_type[-1]
+        return collection_type(converted)
 
 
 PAT_XPATH = "//*[contains(concat(' ', normalize-space(@class), ' '), ' pat-')]"

--- a/src/collective/z3cform/datagridfield/datagridfield.py
+++ b/src/collective/z3cform/datagridfield/datagridfield.py
@@ -32,7 +32,6 @@ from zope.schema.interfaces import IObject
 import logging
 import lxml
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/collective/z3cform/datagridfield/datagridfieldobject_input_block.pt
+++ b/src/collective/z3cform/datagridfield/datagridfieldobject_input_block.pt
@@ -10,8 +10,9 @@
 >
   <td class="datagridwidget-block-edit-cell">
 
-    <div tal:repeat="widget python:view.widgets.values()"
-         class="datagridwidget-block-${widget/id} datagridwidget-widget-${widget/field/__name__} ${python:'d-none' if widget.mode == 'hidden' else 'datagridwidget-cell'}">
+    <div class="datagridwidget-block-${widget/id} datagridwidget-widget-${widget/field/__name__} ${python:'d-none' if widget.mode == 'hidden' else 'datagridwidget-cell'}"
+         tal:repeat="widget python:view.widgets.values()"
+    >
 
       <div tal:replace="structure widget/@@ploneform-render-widget"></div>
 

--- a/src/collective/z3cform/datagridfield/datagridfieldobject_input_block.pt
+++ b/src/collective/z3cform/datagridfield/datagridfieldobject_input_block.pt
@@ -10,55 +10,12 @@
 >
   <td class="datagridwidget-block-edit-cell">
 
-    <tal:block tal:repeat="widget python:view.widgets.values()">
+    <div tal:repeat="widget python:view.widgets.values()"
+         class="datagridwidget-block-${widget/id} datagridwidget-widget-${widget/field/__name__} ${python:'d-none' if widget.mode == 'hidden' else 'datagridwidget-cell'}">
 
-      <div tal:define="
-             klass python: widget.klass or '';
-             error python: widget.error and 'error' or '';
-           "
-           tal:attributes="
-             class python:'datagridwidget-block-' + widget.id + ' ' + klass + ' datagridwidget-widget-' + widget.field.__name__ + ' ' + error + ' ' + ('d-none' if widget.mode == 'hidden' else 'datagridwidget-cell');
-           "
-      >
-        <div class="label">
-          <label tal:attributes="
-                   for widget/id;
-                 ">
-            <span tal:content="widget/label"
-                  i18n:translate=""
-            >label</span>
-            <span class="required"
-                  title="Required"
-                  tal:condition="widget/required"
-                  i18n:attributes="title title_required"
-                  i18n:domain="plone"
-            >&nbsp;</span>
+      <div tal:replace="structure widget/@@ploneform-render-widget"></div>
 
-            <span class="formHelp"
-                  tal:define="
-                    description widget/field/description;
-                  "
-                  tal:condition="python:description"
-                  tal:content="structure description"
-                  i18n:translate=""
-            >field description</span>
-          </label>
-        </div>
-
-
-
-        <div class="fieldErrorBox"
-             tal:condition="widget/error"
-        >
-          <span tal:replace="structure widget/error/render"></span>
-        </div>
-
-        <div tal:replace="structure widget/render"></div>
-
-
-      </div>
-
-    </tal:block>
+    </div>
   </td>
 
   <td class="text-nowrap text-end">

--- a/src/collective/z3cform/datagridfield/demo/behavior.py
+++ b/src/collective/z3cform/datagridfield/demo/behavior.py
@@ -43,6 +43,13 @@ class ITableRow(Interface):
         required=False,
     )
 
+    link = schema.TextLine(
+        title="Link",
+        required=False,
+    )
+
+    directives.widget(link="plone.app.z3cform.widgets.link.LinkFieldWidget")
+
 
 @provider(IFormFieldProvider)
 class IDatagridfieldMetadata(model.Schema):

--- a/src/collective/z3cform/datagridfield/demo/editform.pt
+++ b/src/collective/z3cform/datagridfield/demo/editform.pt
@@ -3,10 +3,25 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       lang="en"
-      metal:use-macro="context/main_template/macros/master"
+      metal:use-macro="context/@@main_template/macros/master"
       xml:lang="en"
       i18n:domain="example.conference"
 >
+  <style metal:fill-slot="style_slot">
+    .pat-datagridfield {
+      overflow-x: auto;
+
+      .datagridwidget-cell {
+        min-width: 150px;
+        font-size: 0.85rem;
+      }
+
+      .cell-3, .cell-10, .cell-11 {
+        min-width:350px;
+      }
+    }
+  </style>
+
   <body>
 
     <metal:main fill-slot="main">

--- a/src/collective/z3cform/datagridfield/demo/editform_object.py
+++ b/src/collective/z3cform/datagridfield/demo/editform_object.py
@@ -19,7 +19,6 @@ from zope.interface import Interface
 from zope.schema import getFieldsInOrder
 from zope.schema.fieldproperty import FieldProperty
 
-
 # Uncomment, if you want to try the relationfield
 # from plone.app.vocabularies.catalog import CatalogSource
 # from z3c.relationfield.schema import RelationChoice

--- a/src/collective/z3cform/datagridfield/demo/editform_simple.py
+++ b/src/collective/z3cform/datagridfield/demo/editform_simple.py
@@ -6,19 +6,18 @@ from ..blockdatagridfield import BlockDataGridFieldWidgetFactory
 from ..datagridfield import DataGridFieldWidgetFactory
 from ..row import DictRow
 from datetime import datetime
+from plone.app.vocabularies.catalog import CatalogSource
 from plone.autoform.directives import widget
 from plone.autoform.form import AutoExtensibleForm
+from plone.namedfile.field import NamedBlobImage
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from z3c.form import button
 from z3c.form import form
 from z3c.form.interfaces import DISPLAY_MODE
 from z3c.form.interfaces import HIDDEN_MODE
+from z3c.relationfield.schema import RelationChoice
 from zope import schema
 from zope.interface import Interface
-
-
-# Uncomment, if you want to try the relationfield
-# from plone.app.vocabularies.catalog import CatalogSource
-# from z3c.relationfield.schema import RelationChoice
 
 
 class IAddress(Interface):
@@ -26,12 +25,11 @@ class IAddress(Interface):
     address_type = schema.Choice(
         title="Address Type", required=True, values=["Work", "Home"]
     )
-    # Uncomment, if you want to try the relationfield
-    #    link = RelationChoice(
-    #        title=u"Link to content",
-    #        source=CatalogSource(portal_type=['Document']),
-    #        required=True
-    #    )
+    internal_link = RelationChoice(
+        title=u"Link to content",
+        source=CatalogSource(portal_type=['Document']),
+        required=False,
+    )
     line2 = schema.TextLine(title="Line 2", required=False)
     city = schema.TextLine(title="City / Town", required=True)
     country = schema.TextLine(title="Country", required=True)
@@ -51,6 +49,18 @@ class IAddress(Interface):
     # A sample checkbox
     billed = schema.Bool(title="Billed")
 
+    profile_image = NamedBlobImage(
+        title="Image",
+        required=False,
+    )
+
+    link = schema.TextLine(
+        title="Link",
+        required=False,
+    )
+
+    widget(link="plone.app.z3cform.widgets.link.LinkFieldWidget")
+
 
 class IPerson(Interface):
     """
@@ -65,7 +75,11 @@ class IPerson(Interface):
         value_type=DictRow(title="Address", schema=IAddress),
         required=True,
     )
-    widget(address=DataGridFieldWidgetFactory)
+    widget(
+        "address",
+        DataGridFieldWidgetFactory,
+        input_table_css_class="table table-striped table-sm",
+    )
 
 
 TESTDATA = {
@@ -101,6 +115,7 @@ class EditForm(AutoExtensibleForm, form.EditForm):
     label = "Simple Form"
     schema = IPerson
     show_note = False
+    template = ViewPageTemplateFile("editform.pt")
 
     def getContent(self):
         return TESTDATA

--- a/src/collective/z3cform/datagridfield/demo/editform_simple.py
+++ b/src/collective/z3cform/datagridfield/demo/editform_simple.py
@@ -26,7 +26,7 @@ class IAddress(Interface):
         title="Address Type", required=True, values=["Work", "Home"]
     )
     internal_link = RelationChoice(
-        title=u"Link to content",
+        title="Link to content",
         source=CatalogSource(portal_type=['Document']),
         required=False,
     )

--- a/src/collective/z3cform/datagridfield/demo/editform_simple.py
+++ b/src/collective/z3cform/datagridfield/demo/editform_simple.py
@@ -27,7 +27,7 @@ class IAddress(Interface):
     )
     internal_link = RelationChoice(
         title="Link to content",
-        source=CatalogSource(portal_type=['Document']),
+        source=CatalogSource(portal_type=["Document"]),
         required=False,
     )
     line2 = schema.TextLine(title="Line 2", required=False)

--- a/src/collective/z3cform/datagridfield/locales/update.py
+++ b/src/collective/z3cform/datagridfield/locales/update.py
@@ -1,7 +1,6 @@
 import os
 import subprocess
 
-
 domain = "collective.z3cform.datagridfield"
 os.chdir("../../../")
 target_path = "src/collective/z3cform/datagridfield/"

--- a/src/collective/z3cform/datagridfield/registry.py
+++ b/src/collective/z3cform/datagridfield/registry.py
@@ -1,6 +1,5 @@
 from collective.z3cform.datagridfield.row import DictRow as BaseDictRow
 
-
 try:
     from plone.registry.field import PersistentField
 except ImportError:

--- a/src/collective/z3cform/datagridfield/row.py
+++ b/src/collective/z3cform/datagridfield/row.py
@@ -1,4 +1,5 @@
 from AccessControl.SecurityManagement import getSecurityManager
+from Acquisition import aq_base
 from collective.z3cform.datagridfield.interfaces import AttributeNotFoundError
 from collective.z3cform.datagridfield.interfaces import IRow
 from plone.app.dexterity.permissions import DXFieldPermissionChecker
@@ -10,7 +11,11 @@ from plone.supermodel.utils import mergedTaggedValueDict
 from z3c.form.converter import BaseDataConverter
 from z3c.form.interfaces import IFieldWidget
 from z3c.form.interfaces import NO_VALUE
+from z3c.form.interfaces import IDataConverter
+from z3c.relationfield.interfaces import IRelation
+from z3c.relationfield.interfaces import IRelationList
 from zope.component import adapter
+from zope.component import queryMultiAdapter
 from zope.component import queryUtility
 from zope.interface import implementer
 from zope.schema import Field
@@ -19,6 +24,26 @@ from zope.schema import Object
 from zope.schema.interfaces import IChoice
 from zope.schema.interfaces import WrongContainedType
 from zope.security.interfaces import IPermission
+
+
+def _sanitize_field_value(fld, value):
+    """Strip acquisition wrappers from a converted field value.
+
+    ContentBrowserDataConverter returns acquisition-wrapped content objects
+    for RelationList/RelationChoice fields. Storing these in ZODB fails with
+    'Can't pickle objects in acquisition wrappers'. Stripping the wrapper
+    stores a plain ZODB persistent reference instead, which is picklable and
+    still usable by IUUID() in toWidgetValue.
+    """
+    if value is None:
+        return value
+    if IRelationList.providedBy(fld):
+        if not value:
+            return value
+        return type(value)(aq_base(item) for item in value if item is not None)
+    if IRelation.providedBy(fld):
+        return aq_base(value)
+    return value
 
 
 @implementer(IRow)
@@ -76,18 +101,42 @@ class DictRowConverter(BaseDataConverter):
                 continue
             converter = self._getConverter(fld)
             val = value.get(name, fld.default)
+            if val is NO_VALUE:
+                # NO_VALUE is a non-picklable sentinel from z3c.form that
+                # widgets (e.g. LinkWidget) return for empty fields. It must
+                # never be stored persistently, so map it to missing_value.
+                _converted[name] = fld.missing_value
+                continue
             try:
-                _converted[name] = converter.toFieldValue(val)
+                _converted[name] = _sanitize_field_value(
+                    fld, converter.toFieldValue(val)
+                )
             except Exception:
                 # XXX: catch exception here in order to not break
                 # versions prior to this fieldValue converter
+                logger.warning(
+                    f"Error converting value for column '{name}' in DictRow: {val!r} ({type(val)})"
+                )
                 _converted[name] = val
         return _converted
 
     def toWidgetValue(self, value):
         _converted = {}
+        # Use the actual sub-widgets if they are already set up on the row
+        # widget (e.g. LinkWidget instead of the default TextWidget).
+        # This ensures that converters for custom widgets (like
+        # LinkWidgetDataConverter) are used, which may expect/return a dict.
+        actual_widgets = getattr(self.widget, "widgets", {})
         for name, fld in self.field.schema.namesAndDescriptions():
-            converter = self._getConverter(fld)
+            sub_widget = actual_widgets.get(name) if actual_widgets else None
+            if sub_widget is not None:
+                converter = queryMultiAdapter(
+                    (fld, sub_widget), IDataConverter
+                )
+            else:
+                converter = None
+            if converter is None:
+                converter = self._getConverter(fld)
             val = value.get(name, fld.default)
             try:
                 _converted[name] = converter.toWidgetValue(val)

--- a/src/collective/z3cform/datagridfield/row.py
+++ b/src/collective/z3cform/datagridfield/row.py
@@ -11,6 +11,7 @@ from plone.supermodel.utils import mergedTaggedValueDict
 from z3c.form.converter import BaseDataConverter
 from z3c.form.interfaces import IDataConverter
 from z3c.form.interfaces import IFieldWidget
+from z3c.form.interfaces import NOT_CHANGED
 from z3c.form.interfaces import NO_VALUE
 from z3c.relationfield.interfaces import IRelation
 from z3c.relationfield.interfaces import IRelationList
@@ -48,6 +49,23 @@ def _sanitize_field_value(fld, value):
     if IRelation.providedBy(fld):
         return aq_base(value)
     return value
+
+
+def _get_stored(stored_row, name, fld):
+    """Return the pre-POST stored value for a row column.
+
+    Accepts either a dict-like ObjectWidgetValue or a plain dict.
+    Falls back to ``fld.missing_value`` when no stored value is found.
+    """
+    if not stored_row:
+        return fld.missing_value
+    try:
+        val = stored_row.get(name, fld.missing_value)
+    except AttributeError:
+        val = getattr(stored_row, name, fld.missing_value)
+    if val is NO_VALUE:
+        return fld.missing_value
+    return val
 
 
 @implementer(IRow)
@@ -97,49 +115,81 @@ class DictRow(Object):
 class DictRowConverter(BaseDataConverter):
     # convert the columns to their field/widget value
 
+    def _getFieldConverter(self, name, fld):
+        """Return the converter for a sub-field.
+
+        Prefer the converter registered for the actual sub-widget (which may
+        be a custom widget set via a ``directives.widget`` declaration, e.g.
+        ``LinkWidget``, ``NamedImageWidget``). Only if no row sub-widget is
+        available (e.g. before ``updateWidgets``), fall back to the default
+        converter for the field type.
+        """
+        sub_widget = None
+        actual_widgets = getattr(self.widget, "widgets", None)
+        if actual_widgets:
+            sub_widget = actual_widgets.get(name)
+        if sub_widget is not None:
+            converter = queryMultiAdapter((fld, sub_widget), IDataConverter)
+            if converter is not None:
+                return converter, sub_widget
+        return self._getConverter(fld), sub_widget
+
     def toFieldValue(self, value):
         _converted = {}
+        # The pre-POST stored row (dict) is stamped onto the row widget by
+        # DataGridFieldWidget.getWidget. Used to resolve NOT_CHANGED results
+        # from sub-converters (e.g. NamedDataConverter on action=nochange)
+        # and NO_VALUE raw extractions from sub-widgets that had no access
+        # to the context (e.g. NamedFileWidget extracted by the fresh row
+        # widgets built inside MultiWidget.extract).
+        stored_row = getattr(self.widget, "_stored_row", None) or {}
         for name, fld in self.field.schema.namesAndDescriptions():
             if fld.readonly:
-                # skip readonly columns
                 continue
-            converter = self._getConverter(fld)
+            converter, sub_widget = self._getFieldConverter(name, fld)
             val = value.get(name, fld.default)
+            # NO_VALUE must never reach a sub-converter: most converters
+            # (e.g. NamedDataConverter) cannot cope with the sentinel. It
+            # appears when a sub-widget had no data and no context to fall
+            # back on - treat it as "keep the stored value", matching the
+            # semantics of NOT_CHANGED.
             if val is NO_VALUE:
-                # NO_VALUE is a non-picklable sentinel from z3c.form that
-                # widgets (e.g. LinkWidget) return for empty fields. It must
-                # never be stored persistently, so map it to missing_value.
-                _converted[name] = fld.missing_value
+                _converted[name] = _sanitize_field_value(
+                    fld, _get_stored(stored_row, name, fld)
+                )
                 continue
             try:
-                _converted[name] = _sanitize_field_value(
-                    fld, converter.toFieldValue(val)
-                )
+                converted = converter.toFieldValue(val)
             except Exception:
-                # XXX: catch exception here in order to not break
-                # versions prior to this fieldValue converter
+                # Defensive: never let a single column break row storage.
                 logger.warning(
-                    f"Error converting value for column '{name}' in DictRow: {val!r} ({type(val)})"
+                    "Error converting value for column %r in DictRow: %r (%s)",
+                    name,
+                    val,
+                    type(val),
                 )
                 _converted[name] = val
+                continue
+
+            if converted is NOT_CHANGED:
+                # Keep the previously stored value (e.g. NamedFile nochange).
+                converted = _get_stored(stored_row, name, fld)
+            if converted is NO_VALUE:
+                # NO_VALUE is a non-picklable sentinel - never store it.
+                converted = fld.missing_value
+            _converted[name] = _sanitize_field_value(fld, converted)
         return _converted
 
     def toWidgetValue(self, value):
         _converted = {}
-        # Use the actual sub-widgets if they are already set up on the row
-        # widget (e.g. LinkWidget instead of the default TextWidget).
-        # This ensures that converters for custom widgets (like
-        # LinkWidgetDataConverter) are used, which may expect/return a dict.
-        actual_widgets = getattr(self.widget, "widgets", {})
         for name, fld in self.field.schema.namesAndDescriptions():
-            sub_widget = actual_widgets.get(name) if actual_widgets else None
-            if sub_widget is not None:
-                converter = queryMultiAdapter((fld, sub_widget), IDataConverter)
-            else:
-                converter = None
-            if converter is None:
-                converter = self._getConverter(fld)
+            converter, _sub_widget = self._getFieldConverter(name, fld)
             val = value.get(name, fld.default)
+            # NO_VALUE can appear here if a previous (buggy) save persisted
+            # it. Normalize to missing_value before handing it to the
+            # sub-converter, which typically cannot cope with the sentinel.
+            if val is NO_VALUE:
+                val = fld.missing_value
             try:
                 _converted[name] = converter.toWidgetValue(val)
             except Exception:

--- a/src/collective/z3cform/datagridfield/row.py
+++ b/src/collective/z3cform/datagridfield/row.py
@@ -130,9 +130,7 @@ class DictRowConverter(BaseDataConverter):
         for name, fld in self.field.schema.namesAndDescriptions():
             sub_widget = actual_widgets.get(name) if actual_widgets else None
             if sub_widget is not None:
-                converter = queryMultiAdapter(
-                    (fld, sub_widget), IDataConverter
-                )
+                converter = queryMultiAdapter((fld, sub_widget), IDataConverter)
             else:
                 converter = None
             if converter is None:

--- a/src/collective/z3cform/datagridfield/row.py
+++ b/src/collective/z3cform/datagridfield/row.py
@@ -9,9 +9,9 @@ from plone.autoform.interfaces import WRITE_PERMISSIONS_KEY
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel.utils import mergedTaggedValueDict
 from z3c.form.converter import BaseDataConverter
+from z3c.form.interfaces import IDataConverter
 from z3c.form.interfaces import IFieldWidget
 from z3c.form.interfaces import NO_VALUE
-from z3c.form.interfaces import IDataConverter
 from z3c.relationfield.interfaces import IRelation
 from z3c.relationfield.interfaces import IRelationList
 from zope.component import adapter

--- a/src/collective/z3cform/datagridfield/row.py
+++ b/src/collective/z3cform/datagridfield/row.py
@@ -11,8 +11,8 @@ from plone.supermodel.utils import mergedTaggedValueDict
 from z3c.form.converter import BaseDataConverter
 from z3c.form.interfaces import IDataConverter
 from z3c.form.interfaces import IFieldWidget
-from z3c.form.interfaces import NOT_CHANGED
 from z3c.form.interfaces import NO_VALUE
+from z3c.form.interfaces import NOT_CHANGED
 from z3c.relationfield.interfaces import IRelation
 from z3c.relationfield.interfaces import IRelationList
 from zope.component import adapter

--- a/src/collective/z3cform/datagridfield/row.py
+++ b/src/collective/z3cform/datagridfield/row.py
@@ -25,6 +25,10 @@ from zope.schema.interfaces import IChoice
 from zope.schema.interfaces import WrongContainedType
 from zope.security.interfaces import IPermission
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 def _sanitize_field_value(fld, value):
     """Strip acquisition wrappers from a converted field value.

--- a/src/collective/z3cform/datagridfield/supermodel.py
+++ b/src/collective/z3cform/datagridfield/supermodel.py
@@ -1,5 +1,4 @@
 from collective.z3cform.datagridfield.row import DictRow
 from plone.supermodel.exportimport import ObjectHandler
 
-
 DictRowHandler = ObjectHandler(DictRow)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [tox]
 # We need 4.4.0 for constrain_package_deps.
@@ -19,6 +19,7 @@ envlist =
 # Add extra configuration options in .meta.toml:
 # - to specify a custom testing combination of Plone and python versions, use `test_matrix`
 #   Use ["*"] to use all supported Python versions for this Plone version.
+# - to disable the test matrix entirely, set `use_test_matrix = false`
 # - to specify extra custom environments, use `envlist_lines`
 # - to specify extra `tox` top-level options, use `config_lines`
 #  [tox]
@@ -66,9 +67,9 @@ description = check if the package defines all its dependencies
 skip_install = true
 deps =
     build
-    z3c.dependencychecker==2.14.3
+    z3c.dependencychecker==3.0
 commands =
-    python -m build --sdist
+    python -m build --wheel
     dependencychecker
 
 [testenv:dependencies-graph]
@@ -99,7 +100,7 @@ coverage =
 description = shared configuration for tests and coverage
 use_develop = true
 skip_install = false
-constrain_package_deps = false
+constrain_package_deps = true
 set_env =
     ROBOT_BROWSER=headlesschrome
 
@@ -136,6 +137,7 @@ extras =
 ##
 # Add extra configuration options in .meta.toml:
 #  [tox]
+#  skip_test_extra = true
 #  test_extras = """
 #      tests
 #      widgets


### PR DESCRIPTION
# Fix: Complex column widgets (LinkWidget, RelationList, NamedBlobImage) inside DictRow

## Problem

When using complex widget types as columns in a `DictRow` schema — specifically
`LinkFieldWidget`, `RelationList`/`RelationChoice`, and `NamedBlobImage` — several
bugs occurred during form save and re-edit:

1. **`_pickle.PicklingError`** — `LinkWidget` returns the `NO_VALUE` sentinel for
   empty fields. `NO_VALUE` is not ZODB-picklable, crashing the save.

2. **`TypeError: Can't pickle objects in acquisition wrappers`** —
   `ContentBrowserDataConverter` returns acquisition-wrapped content objects for
   relation fields. These cannot be stored in ZODB.

3. **`LinkWidget` not pre-populated on re-edit** — `DictRowConverter.toWidgetValue`
   always used the default (field-type-based) converter, ignoring the actual
   registered widget converter (e.g. `LinkWidgetDataConverter`, which expects a
   `dict`, not a plain string).

4. **`NamedBlobImage` silently deleted on second save** — `NamedDataConverter`
   checks `request.get("<widget-name>.action")` to detect the `nochange` action.
   Because `DictRowConverter` used a freshly instantiated, unnamed widget, the
   request key never matched, the converter returned `NOT_CHANGED`, and
   `NOT_CHANGED` was never resolved — so `None`/`missing_value` was stored instead
   of the existing image.

5. **`NO_VALUE` warning spam in logs** — `NO_VALUE` sentinels from sub-widgets were
   passed directly to converters that cannot handle them.

## Root Causes

**`DictRowConverter`** always looked up converters via `_getConverter(fld)`, which
picks the converter registered for the field *type* — never the one registered for
the actual *widget instance*. Custom widgets with their own converters were
completely ignored.

**`z3c.form.converter.MultiConverter`** (the default converter for
`IList`/`IDataGridFieldWidget`) creates a brand-new, unbound row widget on every
`toFieldValue` call. This fresh widget has no name, no stored-row reference, and no
connection to the running form — making `action=nochange` detection impossible.

The pre-POST stored row value (needed to resolve `NOT_CHANGED` from
`NamedDataConverter`) was inaccessible during the POST extraction cycle because
`ObjectWidget` forces `ignoreContext=True` on all its sub-widgets.

## Solution

### `DictRowConverter` improvements

- New helper `_get_stored(stored_row, name, fld)`: safely reads a column value from
  the pre-POST stored row dict (supports both `dict.get()` and `getattr()`-style
  access).

- New method `_getFieldConverter(name, fld)`: prefers the converter registered for
  the *actual sub-widget* (`queryMultiAdapter((fld, sub_widget), IDataConverter)`).
  Falls back to `_getConverter(fld)` only if no real widget is available yet.

- `toFieldValue`: reads `self.widget._stored_row` (stamped by
  `DataGridFieldWidget.getWidget`, see below). `NO_VALUE` raw values are now treated
  as "keep stored value" (same semantics as `NOT_CHANGED`). `NOT_CHANGED` return
  values from sub-converters are resolved to the stored value. `NO_VALUE` in the
  converted result is normalized to `missing_value` before storage.

- `toWidgetValue`: delegates to `_getFieldConverter` and normalizes `NO_VALUE` to
  `missing_value` before passing to sub-converters.

### `DataGridFieldWidget` additions

- New method `_get_stored_rows()`: reads the current field value from the data
  manager and returns it as a list. Returns `None` on add forms or when
  `ignoreContext=True`.

- `getWidget(idx)`: stamps `widget._stored_row = stored_rows[idx]` (or `None` for
  new rows) on every row widget before `widget.update()`.

### New `DataGridFieldConverter`

Replaces `z3c.form.converter.MultiConverter` for the outer list conversion
(`IList` × `IDataGridFieldWidget`):

- **`toFieldValue`**: iterates the *real* row widgets (`self.widget.widgets`,
  excluding `AA`/`TT` template rows). For new rows appended in the browser,
  `getWidget(idx)` is called to produce a properly stamped widget. Dispatches each
  row through the correct `DictRowConverter` bound to the real widget.

- **`toWidgetValue`**: dispatches each stored item through the real row widget's
  converter so that custom sub-widget converters (e.g. `LinkWidgetDataConverter`)
  are used when converting stored values back to widget representation.

## Compatibility

No public API changes. The new `DataGridFieldConverter` is registered as a more
specific adapter (`IList` × `IDataGridFieldWidget`) and only takes effect for
`DataGridFieldWidget`; all other `IList` widgets continue to use the existing
`MultiConverter`. The `_stored_row` attribute stamped on row widgets is an
implementation detail with no impact on external code.
